### PR TITLE
* Ignore pages with only zero-length packets

### DIFF
--- a/NVorbis/Ogg/ForwardOnlyPacketProvider.cs
+++ b/NVorbis/Ogg/ForwardOnlyPacketProvider.cs
@@ -53,6 +53,17 @@ namespace NVorbis.Ogg
                 _lastSeqNo = seqNo;
             }
 
+            // there must be at least one packet with data
+            var ttl = 0;
+            for (var i = 0; i < buf[26]; i++)
+            {
+                ttl += buf[27 + i];
+            }
+            if (ttl == 0)
+            {
+                return false;
+            }
+
             _pageQueue.Enqueue((buf, isResync));
             return true;
         }

--- a/NVorbis/Ogg/ForwardOnlyPageReader.cs
+++ b/NVorbis/Ogg/ForwardOnlyPageReader.cs
@@ -38,13 +38,15 @@ namespace NVorbis.Ogg
 
             // try to add the stream to the list.
             pp = CreatePacketProvider(this, streamSerial);
-            pp.AddPage(pageBuf, isResync);
-            _packetProviders.Add(streamSerial, pp);
-            if (_newStreamCallback(pp))
+            if (pp.AddPage(pageBuf, isResync))
             {
-                return true;
+                _packetProviders.Add(streamSerial, pp);
+                if (_newStreamCallback(pp))
+                {
+                    return true;
+                }
+                _packetProviders.Remove(streamSerial);
             }
-            _packetProviders.Remove(streamSerial);
             return false;
         }
 

--- a/NVorbis/Ogg/PageReader.cs
+++ b/NVorbis/Ogg/PageReader.cs
@@ -125,6 +125,10 @@ namespace NVorbis.Ogg
         {
             PageOffset = StreamPosition - pageBuf.Length;
             ParsePageHeader(pageBuf, streamSerial, isResync);
+
+            // if the page doesn't have any packets, we can't use it
+            if (PacketCount == 0) return false;
+
             _packets = ReadPackets(PacketCount, new Span<byte>(pageBuf, 27, pageBuf[26]), new Memory<byte>(pageBuf, 27 + pageBuf[26], pageBuf.Length - 27 - pageBuf[26]));
 
             if (_streamReaders.TryGetValue(streamSerial, out var spr))


### PR DESCRIPTION
Don't return pages that have no packet data.  Fixes #6 