### PR TITLE
Added support for reading samples into Span<float>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ _ReSharper*/
 
 *.[Rr]e[Ss]harper
 
+# Idea/Rider is a .NET IDE by the creators of ReSharper.
+/.idea/
+
 # NCrunch
 *.ncrunch*
 .*crunch*.local.xml

--- a/NVorbis/Contracts/IStreamDecoder.cs
+++ b/NVorbis/Contracts/IStreamDecoder.cs
@@ -59,12 +59,12 @@ namespace NVorbis.Contracts
         long SamplePosition { get; set; }
 
         /// <summary>
-        /// Gets or sets whether to clip samples returned by <see cref="Read(float[], int, int)"/>.
+        /// Gets or sets whether to clip samples returned by <see cref="Read(Span&lt;float&gt;, int, int)"/>.
         /// </summary>
         bool ClipSamples { get; set; }
 
         /// <summary>
-        /// Gets whether <see cref="Read(float[], int, int)"/> has returned any clipped samples.
+        /// Gets whether <see cref="Read(Span&lt;float&gt;, int, int)"/> has returned any clipped samples.
         /// </summary>
         bool HasClipped { get; }
 
@@ -101,6 +101,6 @@ namespace NVorbis.Contracts
         /// <returns>The number of samples read into the buffer.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the buffer is too small or <paramref name="offset"/> is less than zero.</exception>
         /// <remarks>The data populated into <paramref name="buffer"/> is interleaved by channel in normal PCM fashion: Left, Right, Left, Right, Left, Right</remarks>
-        int Read(float[] buffer, int offset, int count);
+        int Read(Span<float> buffer, int offset, int count);
     }
 }

--- a/NVorbis/StreamDecoder.cs
+++ b/NVorbis/StreamDecoder.cs
@@ -311,7 +311,7 @@ namespace NVorbis
         /// <returns>The number of samples read into the buffer.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the buffer is too small or <paramref name="offset"/> is less than zero.</exception>
         /// <remarks>The data populated into <paramref name="buffer"/> is interleaved by channel in normal PCM fashion: Left, Right, Left, Right, Left, Right</remarks>
-        public int Read(float[] buffer, int offset, int count)
+        public int Read(Span<float> buffer, int offset, int count)
         {
             if (buffer == null) throw new ArgumentNullException(nameof(buffer));
             if (offset < 0 || offset + count > buffer.Length) throw new ArgumentOutOfRangeException(nameof(offset));
@@ -382,7 +382,7 @@ namespace NVorbis
             return count;
         }
 
-        private int ClippingCopyBuffer(float[] target, int targetIndex, int count)
+        private int ClippingCopyBuffer(Span<float> target, int targetIndex, int count)
         {
             var idx = targetIndex;
             for (; count > 0; _prevPacketStart++, count--)
@@ -395,7 +395,7 @@ namespace NVorbis
             return idx - targetIndex;
         }
 
-        private int CopyBuffer(float[] target, int targetIndex, int count)
+        private int CopyBuffer(Span<float> target, int targetIndex, int count)
         {
             var idx = targetIndex;
             for (; count > 0; _prevPacketStart++, count--)
@@ -706,12 +706,12 @@ namespace NVorbis
         }
 
         /// <summary>
-        /// Gets or sets whether to clip samples returned by <see cref="Read(float[], int, int)"/>.
+        /// Gets or sets whether to clip samples returned by <see cref="Read(Span&lt;float&gt;, int, int)"/>.
         /// </summary>
         public bool ClipSamples { get; set; }
 
         /// <summary>
-        /// Gets whether <see cref="Read(float[], int, int)"/> has returned any clipped samples.
+        /// Gets whether <see cref="Read(Span&lt;float&gt;, int, int)"/> has returned any clipped samples.
         /// </summary>
         public bool HasClipped => _hasClipped;
 

--- a/NVorbis/VorbisReader.cs
+++ b/NVorbis/VorbisReader.cs
@@ -345,6 +345,24 @@ namespace NVorbis
         }
 
         /// <summary>
+        /// Reads samples into the specified buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to read the samples into.</param>
+        /// <returns>The number of floats read into the buffer.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the buffer is too small.</exception>
+        /// <remarks>The data populated into <paramref name="buffer"/> is interleaved by channel in normal PCM fashion: Left, Right, Left, Right, Left, Right</remarks>
+        public int ReadSamples(Span<float> buffer)
+        {
+            // don't allow non-aligned reads (always on a full sample boundary!)
+            int count = buffer.Length - buffer.Length % _streamDecoder.Channels;
+            if (!buffer.IsEmpty)
+            {
+                return _streamDecoder.Read(buffer, 0, count);
+            }
+            return 0;
+        }
+
+        /// <summary>
         /// Acknowledges a parameter change as signalled by <see cref="ReadSamples(float[], int, int)"/>.
         /// </summary>
         [Obsolete("No longer needed.", true)]


### PR DESCRIPTION
This is a fairly simple pull request that adds support for reading audio samples into a `Span<float>` in addition to the existing `float[]` array. It adds an overload to `VorbisReader.ReadSamples` that takes a single `Span<float>` parameter (similar to how `System.IO.Stream` has an overload of `Read` that takes a single `Span<byte>` parameter). It also changes `IStreamDecoder.Read`/`StreamDecoder.Read` to use `Span<float>` instead of `float[]`, which shouldn't break anything since `float[]` is implicitly and cheaply cast to `Span<float>`.

I had a few motivations for doing this:

1. Maintain consistency with the modern `System.IO.Stream` API.
2. `Span<float>` allows samples to be read directly into unmanaged memory without having to read them into a temporary `float[]` buffer first.
3. `Span<T>` can be easily reinterpret-cast to a different `T` type, which allows samples to be read into buffers of type other than `float` without an extra copy. For example, in my use case I need to read the samples into a `byte[]`. Previously I had to first read the samples into a `float[]` and then do an unsafe copy into my `byte[]`, but by using `Span<T>` I can simply reinterpret the `byte[]` as a `Span<float>` and read the samples directly into my buffer without an extra copy.