### PR TITLE
Ogg reader fixes

### DIFF
--- a/NVorbis/Ogg/PageReader.cs
+++ b/NVorbis/Ogg/PageReader.cs
@@ -34,9 +34,10 @@ namespace NVorbis.Ogg
             var size = 0;
             for (int i = 0, idx = 27; i < segCnt; i++, idx++)
             {
-                size += pageBuf[idx];
-                dataLen += size;
-                if (pageBuf[idx] < 255)
+                var seg = pageBuf[idx];
+                size += seg;
+                dataLen += seg;
+                if (seg < 255)
                 {
                     if (size > 0)
                     {


### PR DESCRIPTION
Fixes #13 and fixes #14.  Page data size calculation was incorrect, granule position handling was too strict when no granules complete on the page, and packet caching in StreamPageReader was getting confused.