### PR TITLE
Fix invalid cast in TagData.All property

### DIFF
--- a/NVorbis/TagData.cs
+++ b/NVorbis/TagData.cs
@@ -9,13 +9,13 @@ namespace NVorbis
     {
         static IReadOnlyList<string> s_emptyList = new List<string>();
 
-        Dictionary<string, IList<string>> _tags;
+        Dictionary<string, IReadOnlyList<string>> _tags;
 
         public TagData(string vendor, string[] comments)
         {
             EncoderVendor = vendor;
 
-            var tags = new Dictionary<string, IList<string>>();
+            var tags = new Dictionary<string, IReadOnlyList<string>>();
             for (var i = 0; i < comments.Length; i++)
             {
                 var parts = comments[i].Split('=');
@@ -36,7 +36,7 @@ namespace NVorbis
 
                 if (tags.TryGetValue(parts[0].ToUpperInvariant(), out var list))
                 {
-                    list.Add(parts[1]);
+                    ((List<string>)list).Add(parts[1]);
                 }
                 else
                 {
@@ -64,12 +64,12 @@ namespace NVorbis
         {
             if (_tags.TryGetValue(key.ToUpperInvariant(), out var values))
             {
-                return (IReadOnlyList<string>)values;
+                return values;
             }
             return s_emptyList;
         }
 
-        public IReadOnlyDictionary<string, IReadOnlyList<string>> All => (IReadOnlyDictionary<string, IReadOnlyList<string>>)_tags;
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> All => _tags;
 
         public string EncoderVendor { get; }
 


### PR DESCRIPTION
Hello!

I've ran into a bug while accessing the All property on the Tags - the cast seems invalid. This seemed like the most direct way to fix it.

- The IReadOnlyDictionary isn't covariant and can't change the IList<string> of the internal dictionary to IReadOnlyList<string>
- Changed the internal dictionary to use IReadOnlyList<string> instead of IList<string> since we only need to cast it back to the writeable list during the initialization

Thanks for all your work on this project by the way! Been using it for a while and it's awesome to have more audio codecs in C#