### PR TITLE
Fix SeekOrigin.Current seeking backward instead of forward

### DIFF
--- a/NVorbis.Tests/NVorbis.Tests.csproj
+++ b/NVorbis.Tests/NVorbis.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NVorbis\NVorbis.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\TestFiles\*.ogg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>TestFiles\%(Filename)%(Extension)</Link>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/NVorbis.Tests/SeekTests.cs
+++ b/NVorbis.Tests/SeekTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace NVorbis.Tests
+{
+    public class SeekTests
+    {
+        private static string TestFile(string name) =>
+            Path.Combine(AppContext.BaseDirectory, "TestFiles", name);
+
+        // 3test.ogg is long enough for seek tests
+        private const string OggFile = "3test.ogg";
+
+        [Fact]
+        public void SeekOriginCurrent_PositiveOffset_AdvancesPosition()
+        {
+            using var reader = new VorbisReader(TestFile(OggFile));
+
+            // advance ~1 second to establish a non-zero position
+            var buf = new float[reader.SampleRate * reader.Channels];
+            reader.ReadSamples(buf, 0, buf.Length);
+
+            var before = reader.SamplePosition;
+            const long offset = 1000L;
+
+            reader.SeekTo(offset, SeekOrigin.Current);
+
+            Assert.Equal(before + offset, reader.SamplePosition);
+        }
+
+        [Fact]
+        public void SeekOriginCurrent_ZeroOffset_KeepsPosition()
+        {
+            using var reader = new VorbisReader(TestFile(OggFile));
+
+            var buf = new float[reader.SampleRate * reader.Channels];
+            reader.ReadSamples(buf, 0, buf.Length);
+
+            var before = reader.SamplePosition;
+
+            reader.SeekTo(0L, SeekOrigin.Current);
+
+            Assert.Equal(before, reader.SamplePosition);
+        }
+
+        [Fact]
+        public void SeekOriginCurrent_LargeOffset_DoesNotGoBackward()
+        {
+            using var reader = new VorbisReader(TestFile(OggFile));
+
+            // start at 2 seconds in
+            var buf = new float[reader.SampleRate * reader.Channels * 2];
+            reader.ReadSamples(buf, 0, buf.Length);
+
+            var before = reader.SamplePosition;
+            const long offset = 5000L;
+
+            reader.SeekTo(offset, SeekOrigin.Current);
+
+            // must be strictly forward
+            Assert.True(reader.SamplePosition > before,
+                $"Expected position > {before} but got {reader.SamplePosition}");
+            Assert.Equal(before + offset, reader.SamplePosition);
+        }
+
+        [Fact]
+        public void SeekOriginBegin_SeeksToAbsolutePosition()
+        {
+            using var reader = new VorbisReader(TestFile(OggFile));
+
+            reader.SeekTo(1000L, SeekOrigin.Begin);
+
+            Assert.Equal(1000L, reader.SamplePosition);
+        }
+    }
+}

--- a/NVorbis.sln
+++ b/NVorbis.sln
@@ -25,20 +25,54 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Git Settings", "Git Setting
 		.gitignore = .gitignore
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NVorbis.Tests", "NVorbis.Tests\NVorbis.Tests.csproj", "{2F78D968-76CC-4C8C-BFE1-DD4983A9412D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A372E591-DFEF-49C4-9C82-98C4361EFCCD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A372E591-DFEF-49C4-9C82-98C4361EFCCD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A372E591-DFEF-49C4-9C82-98C4361EFCCD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A372E591-DFEF-49C4-9C82-98C4361EFCCD}.Debug|x64.Build.0 = Debug|Any CPU
+		{A372E591-DFEF-49C4-9C82-98C4361EFCCD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A372E591-DFEF-49C4-9C82-98C4361EFCCD}.Debug|x86.Build.0 = Debug|Any CPU
 		{A372E591-DFEF-49C4-9C82-98C4361EFCCD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A372E591-DFEF-49C4-9C82-98C4361EFCCD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A372E591-DFEF-49C4-9C82-98C4361EFCCD}.Release|x64.ActiveCfg = Release|Any CPU
+		{A372E591-DFEF-49C4-9C82-98C4361EFCCD}.Release|x64.Build.0 = Release|Any CPU
+		{A372E591-DFEF-49C4-9C82-98C4361EFCCD}.Release|x86.ActiveCfg = Release|Any CPU
+		{A372E591-DFEF-49C4-9C82-98C4361EFCCD}.Release|x86.Build.0 = Release|Any CPU
 		{902AD24A-6F7C-4F21-9E88-2B9151AEB563}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{902AD24A-6F7C-4F21-9E88-2B9151AEB563}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{902AD24A-6F7C-4F21-9E88-2B9151AEB563}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{902AD24A-6F7C-4F21-9E88-2B9151AEB563}.Debug|x64.Build.0 = Debug|Any CPU
+		{902AD24A-6F7C-4F21-9E88-2B9151AEB563}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{902AD24A-6F7C-4F21-9E88-2B9151AEB563}.Debug|x86.Build.0 = Debug|Any CPU
 		{902AD24A-6F7C-4F21-9E88-2B9151AEB563}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{902AD24A-6F7C-4F21-9E88-2B9151AEB563}.Release|Any CPU.Build.0 = Release|Any CPU
+		{902AD24A-6F7C-4F21-9E88-2B9151AEB563}.Release|x64.ActiveCfg = Release|Any CPU
+		{902AD24A-6F7C-4F21-9E88-2B9151AEB563}.Release|x64.Build.0 = Release|Any CPU
+		{902AD24A-6F7C-4F21-9E88-2B9151AEB563}.Release|x86.ActiveCfg = Release|Any CPU
+		{902AD24A-6F7C-4F21-9E88-2B9151AEB563}.Release|x86.Build.0 = Release|Any CPU
+		{2F78D968-76CC-4C8C-BFE1-DD4983A9412D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F78D968-76CC-4C8C-BFE1-DD4983A9412D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2F78D968-76CC-4C8C-BFE1-DD4983A9412D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2F78D968-76CC-4C8C-BFE1-DD4983A9412D}.Debug|x64.Build.0 = Debug|Any CPU
+		{2F78D968-76CC-4C8C-BFE1-DD4983A9412D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2F78D968-76CC-4C8C-BFE1-DD4983A9412D}.Debug|x86.Build.0 = Debug|Any CPU
+		{2F78D968-76CC-4C8C-BFE1-DD4983A9412D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2F78D968-76CC-4C8C-BFE1-DD4983A9412D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2F78D968-76CC-4C8C-BFE1-DD4983A9412D}.Release|x64.ActiveCfg = Release|Any CPU
+		{2F78D968-76CC-4C8C-BFE1-DD4983A9412D}.Release|x64.Build.0 = Release|Any CPU
+		{2F78D968-76CC-4C8C-BFE1-DD4983A9412D}.Release|x86.ActiveCfg = Release|Any CPU
+		{2F78D968-76CC-4C8C-BFE1-DD4983A9412D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NVorbis/StreamDecoder.cs
+++ b/NVorbis/StreamDecoder.cs
@@ -570,7 +570,7 @@ namespace NVorbis
                     // no-op
                     break;
                 case SeekOrigin.Current:
-                    samplePosition = SamplePosition - samplePosition;
+                    samplePosition = SamplePosition + samplePosition;
                     break;
                 case SeekOrigin.End:
                     samplePosition = TotalSamples - samplePosition;


### PR DESCRIPTION
## Summary

- `SeekTo(offset, SeekOrigin.Current)` computed `SamplePosition - offset`, moving the stream **backward** for positive offsets
- Fix: subtraction changed to addition
- `SeekOrigin.End` correctly uses subtraction; `SeekOrigin.Current` was inconsistent with standard `System.IO.SeekOrigin` semantics

## Test plan

Adds `NVorbis.Tests` xUnit project (net10.0) with four tests:

- [x] `SeekOriginCurrent_PositiveOffset_AdvancesPosition` — seek +1000 samples from mid-stream lands at before + 1000
- [x] `SeekOriginCurrent_ZeroOffset_KeepsPosition` — seek +0 from current is a no-op
- [x] `SeekOriginCurrent_LargeOffset_DoesNotGoBackward` — seek +5000 strictly advances position
- [x] `SeekOriginBegin_SeeksToAbsolutePosition` — regression guard, Begin seek unaffected

All 4 tests pass with the fix applied.

Generated with [Claude Code](https://claude.com/claude-code)