### PR TITLE
Fix FastRange indexer off-by-one

### DIFF
--- a/NVorbis.Tests/CodebookTests.cs
+++ b/NVorbis.Tests/CodebookTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace NVorbis.Tests
+{
+    public class CodebookTests
+    {
+        // FastRange is a private nested class inside Codebook — access via reflection.
+        private static readonly Type _fastRangeType =
+            typeof(Codebook).GetNestedType("FastRange", BindingFlags.NonPublic)!;
+
+        private static readonly MethodInfo _getMethod =
+            _fastRangeType.GetMethod("Get", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        private static readonly PropertyInfo _indexer =
+            _fastRangeType.GetProperty("Item")!;
+
+        private static object MakeRange(int start, int count) =>
+            _getMethod.Invoke(null, new object[] { start, count })!;
+
+        private static int GetItem(object range, int index) =>
+            (int)_indexer.GetValue(range, new object[] { index })!;
+
+        [Fact]
+        public void Indexer_ValidLastIndex_ReturnsCorrectValue()
+        {
+            var range = MakeRange(start: 5, count: 10);
+            Assert.Equal(14, GetItem(range, 9)); // start + (count-1) = 5+9
+        }
+
+        [Fact]
+        public void Indexer_IndexEqualToCount_ThrowsArgumentOutOfRangeException()
+        {
+            // index == count is one-past-end: must throw, not return start+count
+            var range = MakeRange(start: 5, count: 10);
+
+            var ex = Assert.Throws<TargetInvocationException>(() => GetItem(range, 10));
+            Assert.IsType<ArgumentOutOfRangeException>(ex.InnerException);
+        }
+
+        [Fact]
+        public void Indexer_IndexBeyondCount_ThrowsArgumentOutOfRangeException()
+        {
+            var range = MakeRange(start: 0, count: 5);
+
+            var ex = Assert.Throws<TargetInvocationException>(() => GetItem(range, 6));
+            Assert.IsType<ArgumentOutOfRangeException>(ex.InnerException);
+        }
+    }
+}

--- a/NVorbis/Codebook.cs
+++ b/NVorbis/Codebook.cs
@@ -31,7 +31,7 @@ namespace NVorbis
             {
                 get
                 {
-                    if (index > _count) throw new ArgumentOutOfRangeException();
+                    if (index >= _count) throw new ArgumentOutOfRangeException();
                     return _start + index;
                 }
             }


### PR DESCRIPTION
## Summary

- `FastRange.this[int]` checked `index > _count`, so `index == _count` (one-past-end) silently returned `_start + _count` — a wrong Huffman list entry
- Downstream this causes `Codebook` to decode the wrong entry, corrupting audio output or producing an `IndexOutOfRangeException` in the lookup table access
- Fix: `> _count` → `>= _count`

## Test plan

`FastRange` is a private nested class inside `Codebook` — tests use reflection to access it directly:

- [x] `Indexer_ValidLastIndex_ReturnsCorrectValue` — `range[count-1]` returns `start + (count-1)`
- [x] `Indexer_IndexEqualToCount_ThrowsArgumentOutOfRangeException` — the fix: `range[count]` now throws instead of returning garbage
- [x] `Indexer_IndexBeyondCount_ThrowsArgumentOutOfRangeException` — regression guard

All 9 tests pass.

Generated with [Claude Code](https://claude.com/claude-code)