### PR TITLE
Reject zero-Dimensions codebook at load time

### DIFF
--- a/NVorbis.Tests/CodebookTests.cs
+++ b/NVorbis.Tests/CodebookTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Reflection;
 using Xunit;
 
@@ -6,6 +7,16 @@ namespace NVorbis.Tests
 {
     public class CodebookTests
     {
+        // Minimal DataPacket backed by a fixed byte array (bits packed LSB-first).
+        private class ByteArrayPacket : DataPacket
+        {
+            private readonly byte[] _data;
+            private int _pos;
+            public ByteArrayPacket(byte[] data) => _data = data;
+            protected override int TotalBits => _data.Length * 8;
+            protected override int ReadNextByte() => _pos < _data.Length ? _data[_pos++] : -1;
+        }
+
         // FastRange is a private nested class inside Codebook — access via reflection.
         private static readonly Type _fastRangeType =
             typeof(Codebook).GetNestedType("FastRange", BindingFlags.NonPublic)!;
@@ -46,6 +57,39 @@ namespace NVorbis.Tests
 
             var ex = Assert.Throws<TargetInvocationException>(() => GetItem(range, 6));
             Assert.IsType<ArgumentOutOfRangeException>(ex.InnerException);
+        }
+
+        // Codebook.Init validation: Dimensions == 0 must be rejected at load time.
+        // A zero-Dimensions codebook causes an infinite loop in Residue1.WriteVectors
+        // because the inner loop never runs and the outer counter never advances.
+
+        // Header byte layout (LSB-first, as Vorbis packs bits):
+        //   bytes 0-2: sync word 0x564342 → { 0x42, 0x43, 0x56 }
+        //   bytes 3-4: Dimensions (16-bit) → { 0x00, 0x00 } for 0, { 0x01, 0x00 } for 1
+
+        [Fact]
+        public void Init_DimensionsZero_ThrowsInvalidDataException()
+        {
+            var packet = new ByteArrayPacket(new byte[] { 0x42, 0x43, 0x56, 0x00, 0x00 });
+            var codebook = new Codebook();
+
+            var ex = Assert.Throws<InvalidDataException>(() => codebook.Init(packet, null));
+            Assert.Contains("dimension", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Init_DimensionsNonZero_DoesNotThrowDimensionsError()
+        {
+            // Dimensions=1 passes the new check; packet truncates after that so Init
+            // will throw later (bad codebook data), but not with a dimensions message.
+            var packet = new ByteArrayPacket(new byte[] { 0x42, 0x43, 0x56, 0x01, 0x00 });
+            var codebook = new Codebook();
+
+            var ex = Record.Exception(() => codebook.Init(packet, null));
+            Assert.False(
+                ex is InvalidDataException ide &&
+                ide.Message.Contains("dimension", StringComparison.OrdinalIgnoreCase),
+                "Should not throw a dimensions error for Dimensions=1");
         }
     }
 }

--- a/NVorbis/Codebook.cs
+++ b/NVorbis/Codebook.cs
@@ -64,6 +64,7 @@ namespace NVorbis
 
             // get the counts
             Dimensions = (int)packet.ReadBits(16);
+            if (Dimensions < 1) throw new InvalidDataException("Codebook had invalid dimension count!");
             Entries = (int)packet.ReadBits(24);
 
             // init the storage


### PR DESCRIPTION
## Summary

A codebook with `Dimensions == 0` passes `Codebook.Init` silently but causes an **infinite loop** in `Residue1.WriteVectors`:

```csharp
for (int i = 0; i < partitionSize;)          // i never advances
{
    for (int j = 0; j < codebook.Dimensions; i++, j++) // Dimensions=0: never runs
    { ... }
}
```

The outer counter `i` is only incremented inside the inner loop. With `Dimensions == 0` the inner loop body never executes, so the decode thread hangs permanently on any stream containing such a codebook.

**Fix:** throw `InvalidDataException` immediately after reading `Dimensions` in `Codebook.Init` if the value is less than 1, rejecting malformed streams at load time.

## Test plan

- [x] `Init_DimensionsZero_ThrowsInvalidDataException` — codebook header with `Dimensions=0` (bytes `{ 0x42, 0x43, 0x56, 0x00, 0x00 }`) throws `InvalidDataException` containing "dimension"
- [x] `Init_DimensionsNonZero_DoesNotThrowDimensionsError` — `Dimensions=1` does not trigger the new check

All 11 tests pass.

Generated with [Claude Code](https://claude.com/claude-code)