### PR TITLE
Fix ReadSamples(Span<float>) guard to match array overload

### DIFF
--- a/NVorbis.Tests/VorbisReaderTests.cs
+++ b/NVorbis.Tests/VorbisReaderTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace NVorbis.Tests
+{
+    public class VorbisReaderTests
+    {
+        private static string TestFile(string name) =>
+            Path.Combine(AppContext.BaseDirectory, "TestFiles", name);
+
+        [Fact]
+        public void ReadSamples_EmptySpan_ReturnsZero()
+        {
+            using var reader = new VorbisReader(TestFile("3test.ogg"));
+            var result = reader.ReadSamples(Span<float>.Empty);
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
+        public void ReadSamples_SpanShorterThanOneFrame_ReturnsZero()
+        {
+            // count = buffer.Length - buffer.Length % Channels
+            // When buffer.Length < Channels, count == 0: no complete frame fits.
+            // Old guard "!buffer.IsEmpty" passed through to Read(buf, 0, 0) for non-empty buffers.
+            // Correct guard is "count > 0", matching the array overload.
+            using var reader = new VorbisReader(TestFile("3test.ogg"));
+            if (reader.Channels < 2)
+            {
+                // Mono streams have no sub-frame case; skip.
+                return;
+            }
+            var buffer = new float[reader.Channels - 1];
+            var result = reader.ReadSamples(new Span<float>(buffer));
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
+        public void ReadSamples_AlignedSpan_ReturnsData()
+        {
+            using var reader = new VorbisReader(TestFile("3test.ogg"));
+            var buffer = new float[reader.SampleRate * reader.Channels];
+            var result = reader.ReadSamples(new Span<float>(buffer));
+            Assert.True(result > 0, "Expected samples from a valid stream");
+        }
+
+        [Fact]
+        public void ReadSamples_SpanLengthNotAligned_ClampsToFrameBoundary()
+        {
+            // A buffer one float over a frame boundary returns the same count
+            // as one that's exactly on the boundary.
+            using var reader = new VorbisReader(TestFile("3test.ogg"));
+            int channels = reader.Channels;
+            int aligned = reader.SampleRate * channels;
+
+            var bufAligned = new float[aligned];
+            var bufExtra = new float[aligned + 1];
+
+            int r1 = reader.ReadSamples(new Span<float>(bufAligned));
+            reader.SeekTo(0L, SeekOrigin.Begin);
+            int r2 = reader.ReadSamples(new Span<float>(bufExtra));
+
+            Assert.Equal(r1, r2);
+        }
+    }
+}

--- a/NVorbis/VorbisReader.cs
+++ b/NVorbis/VorbisReader.cs
@@ -355,7 +355,7 @@ namespace NVorbis
         {
             // don't allow non-aligned reads (always on a full sample boundary!)
             int count = buffer.Length - buffer.Length % _streamDecoder.Channels;
-            if (!buffer.IsEmpty)
+            if (count > 0)
             {
                 return _streamDecoder.Read(buffer, 0, count);
             }


### PR DESCRIPTION
## Summary

- `ReadSamples(Span<float>)` used `!buffer.IsEmpty` to decide whether to call the underlying `Read`. The array overload `ReadSamples(float[], int, int)` correctly uses `count > 0`.
- When `buffer.Length < Channels` (e.g. a 1-float buffer for a stereo stream) the alignment clamp produces `count = 0`, but `!buffer.IsEmpty` is still `true`, so the old code forwarded a zero-count read to `StreamDecoder.Read` instead of returning immediately.
- Fix: replace `!buffer.IsEmpty` with `count > 0`.

## Test plan

- [x] `ReadSamples_EmptySpan_ReturnsZero` — empty span returns 0
- [x] `ReadSamples_SpanShorterThanOneFrame_ReturnsZero` — span with fewer floats than channels (no complete frame) returns 0
- [x] `ReadSamples_AlignedSpan_ReturnsData` — correctly sized span returns samples
- [x] `ReadSamples_SpanLengthNotAligned_ClampsToFrameBoundary` — extra trailing float doesn't produce extra samples
- [x] All 20 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)