### PR TITLE
Fix Mdct GC pressure and thread-unsafe setup cache

### DIFF
--- a/NVorbis.Tests/MdctTests.cs
+++ b/NVorbis.Tests/MdctTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NVorbis.Tests
+{
+    public class MdctTests
+    {
+        // Smallest legal Vorbis block size; keeps test execution fast.
+        private const int N = 64;
+
+        private static float[] MakeInput(int n, float seed = 1f)
+        {
+            var buf = new float[n];
+            for (int i = 0; i < n; i++)
+                buf[i] = (float)Math.Sin(seed * (i + 1));
+            return buf;
+        }
+
+        private static float[] RunReverse(int n, float seed = 1f)
+        {
+            var mdct = new Mdct();
+            var buf = MakeInput(n, seed);
+            mdct.Reverse(buf, n);
+            return buf;
+        }
+
+        // Item 7: repeated calls must produce identical results (buffer reuse must not bleed state)
+        [Fact]
+        public void Reverse_RepeatedCalls_ProduceSameResult()
+        {
+            var mdct = new Mdct();
+
+            var buf1 = MakeInput(N);
+            var buf2 = MakeInput(N);
+
+            mdct.Reverse(buf1, N);
+            mdct.Reverse(buf2, N);
+
+            Assert.Equal(buf1, buf2);
+        }
+
+        // Item 7: alternating between two block sizes must not corrupt results
+        [Fact]
+        public void Reverse_AlternatingBlockSizes_ProducesConsistentResults()
+        {
+            var mdct = new Mdct();
+            const int N2 = 128;
+
+            var small1 = MakeInput(N);
+            var large1 = MakeInput(N2);
+            mdct.Reverse(small1, N);
+            mdct.Reverse(large1, N2);
+
+            var small2 = MakeInput(N);
+            var large2 = MakeInput(N2);
+            mdct.Reverse(small2, N);
+            mdct.Reverse(large2, N2);
+
+            Assert.Equal(small1, small2);
+            Assert.Equal(large1, large2);
+        }
+
+        // Item 8 + item 7: concurrent calls on the same Mdct instance must not corrupt results
+        [Fact]
+        public void Reverse_ConcurrentCalls_ProduceCorrectIndependentResults()
+        {
+            var mdct = new Mdct();
+
+            // Compute reference output single-threaded.
+            var reference = RunReverse(N);
+
+            const int threadCount = 8;
+            var results = new float[threadCount][];
+            var errors = new Exception[threadCount];
+
+            var barrier = new Barrier(threadCount);
+            var threads = Enumerable.Range(0, threadCount).Select(i => new Thread(() =>
+            {
+                try
+                {
+                    var buf = MakeInput(N);
+                    barrier.SignalAndWait(); // all threads start Reverse simultaneously
+                    mdct.Reverse(buf, N);
+                    results[i] = buf;
+                }
+                catch (Exception ex)
+                {
+                    errors[i] = ex;
+                }
+            })).ToArray();
+
+            foreach (var t in threads) t.Start();
+            foreach (var t in threads) t.Join();
+
+            for (int i = 0; i < threadCount; i++)
+            {
+                Assert.Null(errors[i]);
+                Assert.Equal(reference, results[i]);
+            }
+        }
+
+        // Item 8: Reverse called concurrently with a new sampleCount must not corrupt cache
+        [Fact]
+        public void Reverse_ConcurrentNewSampleCounts_CachePopulatesSafely()
+        {
+            // Two threads simultaneously hit Reverse with block sizes not yet in the cache.
+            const int Na = 64;
+            const int Nb = 128;
+
+            var refA = RunReverse(Na);
+            var refB = RunReverse(Nb);
+
+            const int iterations = 20;
+            for (int iter = 0; iter < iterations; iter++)
+            {
+                var mdct = new Mdct(); // fresh cache each iteration
+                float[] resultA = null, resultB = null;
+                Exception exA = null, exB = null;
+
+                var barrier = new Barrier(2);
+                var tA = new Thread(() =>
+                {
+                    try { var b = MakeInput(Na); barrier.SignalAndWait(); mdct.Reverse(b, Na); resultA = b; }
+                    catch (Exception ex) { exA = ex; }
+                });
+                var tB = new Thread(() =>
+                {
+                    try { var b = MakeInput(Nb); barrier.SignalAndWait(); mdct.Reverse(b, Nb); resultB = b; }
+                    catch (Exception ex) { exB = ex; }
+                });
+
+                tA.Start(); tB.Start();
+                tA.Join(); tB.Join();
+
+                Assert.Null(exA);
+                Assert.Null(exB);
+                Assert.Equal(refA, resultA);
+                Assert.Equal(refB, resultB);
+            }
+        }
+    }
+}

--- a/NVorbis/Mdct.cs
+++ b/NVorbis/Mdct.cs
@@ -8,20 +8,28 @@ namespace NVorbis
     {
         const float M_PI = 3.14159265358979323846264f;
 
+        readonly object _cacheLock = new object();
         Dictionary<int, MdctImpl> _setupCache = new Dictionary<int, MdctImpl>();
 
         public void Reverse(float[] samples, int sampleCount)
         {
-            if (!_setupCache.TryGetValue(sampleCount, out var impl))
+            MdctImpl impl;
+            lock (_cacheLock)
             {
-                impl = new MdctImpl(sampleCount);
-                _setupCache[sampleCount] = impl;
+                if (!_setupCache.TryGetValue(sampleCount, out impl))
+                {
+                    impl = new MdctImpl(sampleCount);
+                    _setupCache[sampleCount] = impl;
+                }
             }
             impl.CalcReverse(samples);
         }
 
         class MdctImpl
         {
+            [ThreadStatic]
+            private static float[] _sharedBuf2;
+
             readonly int _n, _n2, _n4, _n8, _ld;
 
             readonly float[] _a, _b, _c;
@@ -66,7 +74,11 @@ namespace NVorbis
             {
                 float[] u, v;
 
-                var buf2 = new float[_n2];
+                float[] buf2 = _sharedBuf2;
+                if (buf2 == null || buf2.Length < _n2)
+                {
+                    _sharedBuf2 = buf2 = new float[_n2];
+                }
 
                 // copy and reflect spectral data
                 // step 0


### PR DESCRIPTION
## Summary

**Item 7 — per-call allocation in CalcReverse (`Mdct.cs:69`)**
`CalcReverse` allocated `new float[_n2]` on every invocation. This is the hot path in Vorbis decoding (called per-channel per-packet). Replace with a `[ThreadStatic]` buffer that is allocated at most once per thread per block size and reused on every subsequent call. `[ThreadStatic]` keeps threads independent so concurrent callers on different threads don't share state.

**Item 8 — unsynchronised `_setupCache` dictionary (`Mdct.cs:11`)**
`_setupCache` (`Dictionary<int, MdctImpl>`) was accessed without synchronisation. Concurrent `Reverse` calls with a previously-unseen `sampleCount` would race on the `TryGetValue` + assignment pair. Guard access with a `lock`; after the two Vorbis block sizes are cached the lock is never contended during decode.

## Test plan

- [x] `Reverse_RepeatedCalls_ProduceSameResult` — buffer reuse does not bleed state between calls
- [x] `Reverse_AlternatingBlockSizes_ProducesConsistentResults` — switching between two block sizes on one thread produces consistent results
- [x] `Reverse_ConcurrentCalls_ProduceCorrectIndependentResults` — 8 threads calling `Reverse` simultaneously on the same `Mdct` instance each get the correct, independent result
- [x] `Reverse_ConcurrentNewSampleCounts_CachePopulatesSafely` — two threads racing to populate the cache with different block sizes don't corrupt each other (20 iterations)
- [x] All 24 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)