### PR TITLE
Replace Tags lazy init with Lazy<T> for thread safety

### DIFF
--- a/NVorbis.Tests/TagsTests.cs
+++ b/NVorbis.Tests/TagsTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Xunit;
+
+namespace NVorbis.Tests
+{
+    public class TagsTests
+    {
+        private static string TestFile(string name) =>
+            Path.Combine(AppContext.BaseDirectory, "TestFiles", name);
+
+        // Tags.Value must be non-null after successful stream open.
+        [Fact]
+        public void Tags_AfterOpen_IsNotNull()
+        {
+            using var reader = new VorbisReader(TestFile("3test.ogg"));
+            Assert.NotNull(reader.Tags);
+        }
+
+        // Lazy<T> must return the same instance on every access (no re-creation).
+        [Fact]
+        public void Tags_AccessedMultipleTimes_ReturnsSameInstance()
+        {
+            using var reader = new VorbisReader(TestFile("3test.ogg"));
+            var t1 = reader.Tags;
+            var t2 = reader.Tags;
+            Assert.Same(t1, t2);
+        }
+
+        // Concurrent reads must all get the same instance — Lazy<T> with the
+        // default ExecutionAndPublication mode guarantees exactly one construction.
+        // The old "?? (_tags = new TagData(...))" pattern was not thread-safe:
+        // two threads could both observe _tags == null and create separate objects.
+        [Fact]
+        public void Tags_ConcurrentAccess_AllReturnSameInstance()
+        {
+            using var reader = new VorbisReader(TestFile("3test.ogg"));
+
+            const int threadCount = 16;
+            var results = new NVorbis.Contracts.ITagData[threadCount];
+            var barrier = new Barrier(threadCount);
+
+            var threads = Enumerable.Range(0, threadCount).Select(i => new Thread(() =>
+            {
+                barrier.SignalAndWait(); // race all threads to the first Tags access
+                results[i] = reader.Tags;
+            })).ToArray();
+
+            foreach (var t in threads) t.Start();
+            foreach (var t in threads) t.Join();
+
+            for (int i = 1; i < threadCount; i++)
+                Assert.Same(results[0], results[i]);
+        }
+
+        // EncoderVendor must be a non-null string (may be empty for files with no vendor tag).
+        [Fact]
+        public void Tags_EncoderVendor_IsNotNull()
+        {
+            using var reader = new VorbisReader(TestFile("3test.ogg"));
+            Assert.NotNull(reader.Tags.EncoderVendor);
+        }
+
+        // All returns a non-null dictionary (may be empty for files with no comment tags).
+        [Fact]
+        public void Tags_All_IsNotNull()
+        {
+            using var reader = new VorbisReader(TestFile("3test.ogg"));
+            Assert.NotNull(reader.Tags.All);
+        }
+    }
+}

--- a/NVorbis/StreamDecoder.cs
+++ b/NVorbis/StreamDecoder.cs
@@ -25,7 +25,7 @@ namespace NVorbis
 
         private string _vendor;
         private string[] _comments;
-        private ITagData _tags;
+        private Lazy<ITagData> _tags;
 
         private long _currentPosition;
         private bool _hasClipped;
@@ -65,6 +65,8 @@ namespace NVorbis
 
                 throw GetInvalidStreamException(packet);
             }
+
+            _tags = new Lazy<ITagData>(() => new TagData(_vendor, _comments));
         }
 
         private static Exception GetInvalidStreamException(IPacket packet)
@@ -687,7 +689,7 @@ namespace NVorbis
         /// <summary>
         /// Gets the tag data from the stream's header.
         /// </summary>
-        public ITagData Tags => _tags ?? (_tags = new TagData(_vendor, _comments));
+        public ITagData Tags => _tags.Value;
 
         /// <summary>
         /// Gets the total duration of the decoded stream.


### PR DESCRIPTION
## Summary

- `StreamDecoder.Tags` used `_tags ?? (_tags = new TagData(_vendor, _comments))`. This is not atomic: two threads racing on the first access can both observe `_tags == null`, each construct a `TagData`, and return different instances — a silent data race.
- Replace `private ITagData _tags` with `private Lazy<ITagData> _tags`, initialised at the end of the constructor (after header packets are loaded and `_vendor`/`_comments` are set).
- `Lazy<T>` with the default `ExecutionAndPublication` mode guarantees the factory runs exactly once and every caller receives the same instance.
- `Tags` property simplified to `_tags.Value`.

## Test plan

- [x] `Tags_AfterOpen_IsNotNull` — basic smoke test
- [x] `Tags_AccessedMultipleTimes_ReturnsSameInstance` — idempotency: same instance on every call
- [x] `Tags_ConcurrentAccess_AllReturnSameInstance` — 16 threads race to the first `Tags` access; all must receive the same instance
- [x] `Tags_EncoderVendor_IsNotNull` — vendor string is accessible and non-null
- [x] `Tags_All_IsNotNull` — tag dictionary is accessible and non-null
- [x] All 29 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)