### PR TITLE
Dispose containerReader on all VorbisReader constructor failure paths

### DIFF
--- a/NVorbis.Tests/TestAssemblyInfo.cs
+++ b/NVorbis.Tests/TestAssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/NVorbis.Tests/VorbisReaderConstructorTests.cs
+++ b/NVorbis.Tests/VorbisReaderConstructorTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace NVorbis.Tests
+{
+    public class VorbisReaderConstructorTests
+    {
+        // Minimal Contracts.IContainerReader stub with configurable TryInit behaviour.
+        private sealed class StubContainerReader : Contracts.IContainerReader
+        {
+            private readonly Func<bool> _tryInit;
+
+            public bool Disposed { get; private set; }
+            public Contracts.NewStreamHandler NewStreamCallback { get; set; }
+            public bool CanSeek => false;
+            public long ContainerBits => 0;
+            public long WasteBits => 0;
+
+            public StubContainerReader(Func<bool> tryInit) => _tryInit = tryInit;
+
+            public bool TryInit() => _tryInit();
+            public bool FindNextStream() => false;
+            public IReadOnlyList<Contracts.IPacketProvider> GetStreams() =>
+                Array.Empty<Contracts.IPacketProvider>();
+            public void Dispose() => Disposed = true;
+        }
+
+        private static void WithFactory(
+            Func<Stream, bool, Contracts.IContainerReader> factory,
+            Action body)
+        {
+            var original = VorbisReader.CreateContainerReader;
+            VorbisReader.CreateContainerReader = factory;
+            try { body(); }
+            finally { VorbisReader.CreateContainerReader = original; }
+        }
+
+        // When TryInit() throws, containerReader must be disposed — it was leaked before the fix.
+        [Fact]
+        public void Constructor_TryInitThrows_DisposesContainerReader()
+        {
+            StubContainerReader stub = null;
+            WithFactory(
+                (_, __) => stub = new StubContainerReader(() => throw new InvalidOperationException("TryInit failed")),
+                () =>
+                {
+                    Assert.Throws<InvalidOperationException>(() =>
+                        new VorbisReader(Stream.Null, closeOnDispose: false));
+                    Assert.True(stub.Disposed, "containerReader must be disposed when TryInit throws");
+                });
+        }
+
+        // When TryInit() returns false, containerReader must also be disposed (pre-existing behaviour preserved).
+        [Fact]
+        public void Constructor_TryInitReturnsFalse_DisposesContainerReader()
+        {
+            StubContainerReader stub = null;
+            WithFactory(
+                (_, __) => stub = new StubContainerReader(() => false),
+                () =>
+                {
+                    Assert.Throws<ArgumentException>(() =>
+                        new VorbisReader(Stream.Null, closeOnDispose: false));
+                    Assert.True(stub.Disposed, "containerReader must be disposed when TryInit returns false");
+                });
+        }
+
+        // When TryInit() throws and closeOnDispose is true, the stream must be disposed.
+        [Fact]
+        public void Constructor_TryInitThrows_ClosesStreamWhenCloseOnDispose()
+        {
+            var ms = new MemoryStream(new byte[1]);
+            WithFactory(
+                (_, __) => new StubContainerReader(() => throw new InvalidOperationException()),
+                () =>
+                {
+                    Assert.Throws<InvalidOperationException>(() =>
+                        new VorbisReader(ms, closeOnDispose: true));
+                    Assert.Throws<ObjectDisposedException>(() => ms.ReadByte());
+                });
+        }
+
+        // When TryInit() throws and closeOnDispose is false, the stream must NOT be disposed.
+        [Fact]
+        public void Constructor_TryInitThrows_LeavesStreamOpenWhenNotCloseOnDispose()
+        {
+            var ms = new MemoryStream(new byte[1]);
+            WithFactory(
+                (_, __) => new StubContainerReader(() => throw new InvalidOperationException()),
+                () =>
+                {
+                    Assert.Throws<InvalidOperationException>(() =>
+                        new VorbisReader(ms, closeOnDispose: false));
+                    Assert.True(ms.CanRead, "stream must remain open when closeOnDispose is false");
+                });
+        }
+    }
+}

--- a/NVorbis/VorbisReader.cs
+++ b/NVorbis/VorbisReader.cs
@@ -44,9 +44,16 @@ namespace NVorbis
             _decoders = new List<IStreamDecoder>();
 
             var containerReader = CreateContainerReader(stream, closeOnDispose);
-            containerReader.NewStreamCallback = ProcessNewStream;
+            try
+            {
+                containerReader.NewStreamCallback = ProcessNewStream;
 
-            if (!containerReader.TryInit() || _decoders.Count == 0)
+                if (!containerReader.TryInit() || _decoders.Count == 0)
+                {
+                    throw new ArgumentException("Could not load the specified container!", nameof(containerReader));
+                }
+            }
+            catch
             {
                 containerReader.NewStreamCallback = null;
                 containerReader.Dispose();
@@ -56,8 +63,9 @@ namespace NVorbis
                     stream.Dispose();
                 }
 
-                throw new ArgumentException("Could not load the specified container!", nameof(containerReader));
+                throw;
             }
+
             _closeOnDispose = closeOnDispose;
             _containerReader = containerReader;
             _streamDecoder = _decoders[0];


### PR DESCRIPTION
## Summary

- `VorbisReader(Stream, bool)` disposed `containerReader` when `TryInit()` returned `false`, but **not** when it threw an exception — leaving the container reader (and the underlying stream, if `closeOnDispose`) leaked.
- Restructure the constructor to wrap the `TryInit` call in `try/catch`: on any failure (return `false` **or** throw), clear `NewStreamCallback`, dispose `containerReader`, conditionally dispose the stream, then `throw` to propagate the original exception.
- The success path is unchanged.
- Added `[assembly: CollectionBehavior(DisableTestParallelization = true)]` so tests that swap `VorbisReader.CreateContainerReader` (a static) don't race with integration tests using the real factory.

## Test plan

- [x] `Constructor_TryInitThrows_DisposesContainerReader` — `Disposed` is `true` after `TryInit()` throws
- [x] `Constructor_TryInitReturnsFalse_DisposesContainerReader` — pre-existing behaviour preserved: disposed when `TryInit()` returns `false`
- [x] `Constructor_TryInitThrows_ClosesStreamWhenCloseOnDispose` — stream disposed when `closeOnDispose = true`
- [x] `Constructor_TryInitThrows_LeavesStreamOpenWhenNotCloseOnDispose` — stream left open when `closeOnDispose = false`
- [x] All 33 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)