### PR TITLE
Eliminate List<int> allocation per decoded packet

### DIFF
--- a/NVorbis.Tests/PacketTests.cs
+++ b/NVorbis.Tests/PacketTests.cs
@@ -1,0 +1,141 @@
+using NVorbis.Contracts;
+using NVorbis.Contracts.Ogg;
+using NVorbis.Ogg;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace NVorbis.Tests
+{
+    public class PacketTests
+    {
+        private sealed class StubPacketReader : IPacketReader
+        {
+            private readonly Dictionary<int, byte[]> _pages;
+            internal StubPacketReader(Dictionary<int, byte[]> pages) => _pages = pages;
+            public Memory<byte> GetPacketData(int key) => _pages[key];
+            public void InvalidatePacketCache(IPacket packet) { }
+        }
+
+        private static ulong ReadByte(IPacket p) => p.ReadBits(8);
+
+        // ── single-page ──────────────────────────────────────────────────────
+
+        [Fact]
+        public void SinglePage_BitsRemaining_MatchesDataLength()
+        {
+            var data = new byte[] { 1, 2, 3, 4 };
+            var reader = new StubPacketReader(new Dictionary<int, byte[]> { [0] = data });
+            IPacket packet = new Packet(0, reader, data);
+
+            Assert.Equal(data.Length * 8, packet.BitsRemaining);
+        }
+
+        [Fact]
+        public void SinglePage_ReadBits_ReturnsCorrectSequence()
+        {
+            var data = new byte[] { 0xAB, 0xCD, 0xEF };
+            var reader = new StubPacketReader(new Dictionary<int, byte[]> { [0] = data });
+            IPacket packet = new Packet(0, reader, data);
+
+            Assert.Equal(0xABu, ReadByte(packet));
+            Assert.Equal(0xCDu, ReadByte(packet));
+            Assert.Equal(0xEFu, ReadByte(packet));
+            Assert.Equal(0, packet.BitsRemaining);
+        }
+
+        [Fact]
+        public void SinglePage_ReadBitsAtEnd_ReturnsZeroCount()
+        {
+            var data = new byte[] { 0xFF };
+            var reader = new StubPacketReader(new Dictionary<int, byte[]> { [0] = data });
+            var packet = new Packet(0, reader, data);
+
+            ReadByte(packet); // exhaust
+            var val = packet.TryPeekBits(8, out var bitsRead);
+            Assert.Equal(0, bitsRead);
+        }
+
+        [Fact]
+        public void SinglePage_Reset_RestartsReadPosition()
+        {
+            var data = new byte[] { 0x42, 0x99 };
+            var reader = new StubPacketReader(new Dictionary<int, byte[]> { [0] = data });
+            IPacket packet = new Packet(0, reader, data);
+
+            ReadByte(packet); // consume first byte
+            packet.Reset();
+
+            Assert.Equal(0x42u, ReadByte(packet));
+        }
+
+        // ── multi-page ───────────────────────────────────────────────────────
+
+        [Fact]
+        public void MultiPage_ReadBits_SpansPageBoundary()
+        {
+            const int key0 = (0 << 8) | 0;
+            const int key1 = 1 << 8;
+            var part0 = new byte[] { 0xAA, 0xBB };
+            var part1 = new byte[] { 0xCC, 0xDD };
+            var reader = new StubPacketReader(new Dictionary<int, byte[]>
+            {
+                [key0] = part0,
+                [key1] = part1,
+            });
+            IPacket packet = new Packet(key0, new[] { key1 }, reader, part0);
+
+            Assert.Equal(0xAAu, ReadByte(packet));
+            Assert.Equal(0xBBu, ReadByte(packet));
+            Assert.Equal(0xCCu, ReadByte(packet));
+            Assert.Equal(0xDDu, ReadByte(packet));
+            Assert.Equal(0, packet.BitsRemaining);
+        }
+
+        [Fact]
+        public void MultiPage_ThreePages_ReadsBeyondSecondPageBoundary()
+        {
+            const int key0 = (0 << 8) | 0;
+            const int key1 = 1 << 8;
+            const int key2 = 2 << 8;
+            var part0 = new byte[] { 0x01 };
+            var part1 = new byte[] { 0x02 };
+            var part2 = new byte[] { 0x03 };
+            var reader = new StubPacketReader(new Dictionary<int, byte[]>
+            {
+                [key0] = part0,
+                [key1] = part1,
+                [key2] = part2,
+            });
+            IPacket packet = new Packet(key0, new[] { key1, key2 }, reader, part0);
+
+            Assert.Equal(0x01u, ReadByte(packet));
+            Assert.Equal(0x02u, ReadByte(packet));
+            Assert.Equal(0x03u, ReadByte(packet));
+            Assert.Equal(0, packet.BitsRemaining);
+        }
+
+        [Fact]
+        public void MultiPage_Reset_RestartsReadPosition()
+        {
+            const int key0 = (0 << 8) | 0;
+            const int key1 = 1 << 8;
+            var part0 = new byte[] { 0x11, 0x22 };
+            var part1 = new byte[] { 0x33, 0x44 };
+            var reader = new StubPacketReader(new Dictionary<int, byte[]>
+            {
+                [key0] = part0,
+                [key1] = part1,
+            });
+            IPacket packet = new Packet(key0, new[] { key1 }, reader, part0);
+
+            ReadByte(packet);
+            ReadByte(packet);
+            ReadByte(packet);
+            ReadByte(packet);
+            packet.Reset();
+
+            Assert.Equal(0x11u, ReadByte(packet));
+        }
+    }
+}

--- a/NVorbis/Ogg/Packet.cs
+++ b/NVorbis/Ogg/Packet.cs
@@ -1,6 +1,6 @@
-﻿using NVorbis.Contracts.Ogg;
+using NVorbis.Contracts;
+using NVorbis.Contracts.Ogg;
 using System;
-using System.Collections.Generic;
 
 namespace NVorbis.Ogg
 {
@@ -10,28 +10,42 @@ namespace NVorbis.Ogg
         //   x86:  68 bytes
         //   x64: 104 bytes
 
-        // this is the list of pages & packets in packed 24:8 format
-        // in theory, this is good for up to 1016 GiB of Ogg file
-        // in practice, probably closer to 300 days @ 160k bps
-        private IReadOnlyList<int> _dataParts;
+        // _firstPart stores the 24:8 packed (pageIndex:packetIndex) of the first page.
+        // _extraParts stores packed pageIndex values for any continuation pages (null for
+        // the common single-page case, avoiding the List<int> + backing-array allocation).
+        private readonly int _firstPart;
+        private readonly int[] _extraParts;
+        private readonly int _partCount;
         private IPacketReader _packetReader;                    // IntPtr
         int _dataCount;
         Memory<byte> _data;
         int _dataIndex;                                         // 4
         int _dataOfs;                                           // 4
 
-        internal Packet(IReadOnlyList<int> dataParts, IPacketReader packetReader, Memory<byte> initialData)
+        internal Packet(int firstPart, IPacketReader packetReader, Memory<byte> initialData)
         {
-            _dataParts = dataParts;
+            _firstPart = firstPart;
+            _partCount = 1;
             _packetReader = packetReader;
             _data = initialData;
         }
+
+        internal Packet(int firstPart, int[] extraParts, IPacketReader packetReader, Memory<byte> initialData)
+        {
+            _firstPart = firstPart;
+            _extraParts = extraParts;
+            _partCount = 1 + extraParts.Length;
+            _packetReader = packetReader;
+            _data = initialData;
+        }
+
+        private int GetPart(int index) => index == 0 ? _firstPart : _extraParts[index - 1];
 
         protected override int TotalBits => (_dataCount + _data.Length) * 8;
 
         protected override int ReadNextByte()
         {
-            if (_dataIndex == _dataParts.Count) return -1;
+            if (_dataIndex == _partCount) return -1;
 
             var b = _data.Span[_dataOfs];
 
@@ -39,9 +53,9 @@ namespace NVorbis.Ogg
             {
                 _dataOfs = 0;
                 _dataCount += _data.Length;
-                if (++_dataIndex < _dataParts.Count)
+                if (++_dataIndex < _partCount)
                 {
-                    _data = _packetReader.GetPacketData(_dataParts[_dataIndex]);
+                    _data = _packetReader.GetPacketData(GetPart(_dataIndex));
                 }
                 else
                 {
@@ -56,9 +70,9 @@ namespace NVorbis.Ogg
         {
             _dataIndex = 0;
             _dataOfs = 0;
-            if (_dataParts.Count > 0)
+            if (_partCount > 0)
             {
-                _data = _packetReader.GetPacketData(_dataParts[0]);
+                _data = _packetReader.GetPacketData(_firstPart);
             }
 
             base.Reset();

--- a/NVorbis/Ogg/PacketProvider.cs
+++ b/NVorbis/Ogg/PacketProvider.cs
@@ -341,14 +341,14 @@ namespace NVorbis.Ogg
         {
             // save off the packet data for the initial packet
             var firstPacketData = _reader.GetPagePackets(pageIndex)[packetIndex];
-
-            // create the packet list and add the item to it
-            var pktList = new List<int>(2) { (pageIndex << 8) | packetIndex };
+            var firstPart = (pageIndex << 8) | packetIndex;
 
             // make sure we handle continuations
             bool isLastPacket;
             bool isFirstPacket;
             var finalPage = pageIndex;
+            int[] extraParts = null;
+
             if (isContinued && packetIndex == packetCount - 1)
             {
                 // by definition, it's the first packet in the page it ends on
@@ -362,6 +362,7 @@ namespace NVorbis.Ogg
 
                 // go read the next page(s) that include this packet
                 var contPageIdx = pageIndex;
+                List<int> extraList = null;
                 while (isContinued)
                 {
                     if (!_reader.GetPage(++contPageIdx, out granulePos, out isResync, out var isContinuation, out isContinued, out packetCount, out var contPageOverhead))
@@ -383,9 +384,11 @@ namespace NVorbis.Ogg
                         isContinued = false;
                     }
 
-                    // add the packet to the list
-                    pktList.Add(contPageIdx << 8);
+                    // track the continuation page
+                    (extraList ??= new List<int>()).Add(contPageIdx << 8);
                 }
+
+                extraParts = extraList?.ToArray();
 
                 // we're now the first packet in the final page, so we'll act like it...
                 isLastPacket = packetCount == 1;
@@ -399,11 +402,11 @@ namespace NVorbis.Ogg
                 isLastPacket = packetIndex == packetCount - 1;
             }
 
-            // create the packet instance and populate it with the appropriate initial data
-            var packet = new Packet(pktList, this, firstPacketData)
-            {
-                IsResync = isResync,
-            };
+            // create the packet instance — avoid List<int> allocation for the common single-page case
+            var packet = extraParts != null
+                ? new Packet(firstPart, extraParts, this, firstPacketData)
+                : new Packet(firstPart, this, firstPacketData);
+            packet.IsResync = isResync;
 
             // if it's the first packet, associate the container overhead with it
             if (isFirstPacket)

--- a/NVorbis/Ogg/PacketProvider.cs
+++ b/NVorbis/Ogg/PacketProvider.cs
@@ -385,7 +385,8 @@ namespace NVorbis.Ogg
                     }
 
                     // track the continuation page
-                    (extraList ??= new List<int>()).Add(contPageIdx << 8);
+                    if (extraList == null) extraList = new List<int>();
+                    extraList.Add(contPageIdx << 8);
                 }
 
                 extraParts = extraList?.ToArray();


### PR DESCRIPTION
## Summary

- `Packet` previously stored page/packet indices in `IReadOnlyList<int>`, requiring `PacketProvider.CreatePacket` to allocate a `List<int>(2)` (plus its backing `int[2]`) for **every** decoded packet — two heap objects on the common single-page path
- Replace the list with two inline fields: `_firstPart` (int) and `_extraParts` (int[], null for single-page packets)
- `CreatePacket` now allocates nothing for the common case; for the rare multi-page continuation case a `List<int>` is lazily constructed and materialized to `int[]` once

## Details

`Packet._dataParts : IReadOnlyList<int>` → removed  
`Packet._firstPart : int` — packed `(pageIndex << 8) | packetIndex` for the first page (always present, no allocation)  
`Packet._extraParts : int[]` — packed `pageIndex << 8` for each continuation page; `null` for single-page packets  
`Packet._partCount : int` — `1 + (_extraParts?.Length ?? 0)`

`PacketProvider.CreatePacket` replaces `new List<int>(2) { firstEntry }` with a direct `firstPart` int. The continuation loop lazily creates `List<int> extraList` only when a continuation page is encountered, then calls `.ToArray()` once at the end.

## Test plan

- [x] All 49 unit tests pass (`dotnet test`)
- [x] `PacketTests.SinglePage_BitsRemaining_MatchesDataLength`
- [x] `PacketTests.SinglePage_ReadBits_ReturnsCorrectSequence`
- [x] `PacketTests.SinglePage_ReadBitsAtEnd_ReturnsZeroCount`
- [x] `PacketTests.SinglePage_Reset_RestartsReadPosition`
- [x] `PacketTests.MultiPage_ReadBits_SpansPageBoundary`
- [x] `PacketTests.MultiPage_ThreePages_ReadsBeyondSecondPageBoundary`
- [x] `PacketTests.MultiPage_Reset_RestartsReadPosition`

🤖 Generated with [Claude Code](https://claude.com/claude-code)