### PR TITLE
Cache page packets in ReadPageData to eliminate double read on seek

### DIFF
--- a/NVorbis.Tests/StreamPageReaderTests.cs
+++ b/NVorbis.Tests/StreamPageReaderTests.cs
@@ -1,0 +1,71 @@
+using NVorbis.Contracts;
+using NVorbis.Contracts.Ogg;
+using NVorbis.Ogg;
+using System;
+using Xunit;
+
+namespace NVorbis.Tests
+{
+    public class StreamPageReaderTests
+    {
+        private sealed class MockPageData : IPageData
+        {
+            public int ReadPageAtCallCount;
+
+            // Fixed page state: a single non-continued audio page at offset 100
+            public long PageOffset => 100;
+            public int StreamSerial => 0x1234;
+            public int SequenceNumber => 1;
+            public PageFlags PageFlags => PageFlags.None;
+            public long GranulePosition => 1024;
+            public short PacketCount => 1;
+            public bool? IsResync => false;
+            public bool IsContinued => false;
+            public int PageOverhead => 27;
+            public long ContainerBits => 0;
+            public long WasteBits => 0;
+
+            public void Lock() { }
+            public bool Release() => true;
+            public bool ReadNextPage() => false;
+            public bool ReadPageAt(long offset) { ReadPageAtCallCount++; return true; }
+            public Memory<byte>[] GetPackets() => new[] { new Memory<byte>(new byte[] { 0x01, 0x02 }) };
+            public void Dispose() { }
+        }
+
+        [Fact]
+        public void GetPageThenGetPackets_ReadsPageFromDiskOnce()
+        {
+            var mock = new MockPageData();
+            var spr = new StreamPageReader(mock, mock.StreamSerial);
+
+            // register the page (uses current mock state — no ReadPageAt)
+            spr.AddPage();
+
+            // first call: must read from disk
+            spr.GetPage(0, out _, out _, out _, out _, out _, out _);
+            var afterGetPage = mock.ReadPageAtCallCount;
+
+            // second call: packet data should already be cached
+            spr.GetPagePackets(0);
+            var afterGetPackets = mock.ReadPageAtCallCount;
+
+            Assert.Equal(1, afterGetPage);
+            Assert.Equal(1, afterGetPackets); // no second read
+        }
+
+        [Fact]
+        public void GetPagePackets_AfterGetPage_ReturnsCorrectData()
+        {
+            var mock = new MockPageData();
+            var spr = new StreamPageReader(mock, mock.StreamSerial);
+            spr.AddPage();
+
+            spr.GetPage(0, out _, out _, out _, out _, out _, out _);
+            var packets = spr.GetPagePackets(0);
+
+            Assert.Single(packets);
+            Assert.Equal(new byte[] { 0x01, 0x02 }, packets[0].ToArray());
+        }
+    }
+}

--- a/NVorbis/Ogg/StreamPageReader.cs
+++ b/NVorbis/Ogg/StreamPageReader.cs
@@ -368,13 +368,14 @@ namespace NVorbis.Ogg
 
         private void ReadPageData(int pageIndex, out long granulePos, out bool isContinuation, out bool isContinued, out int packetCount, out int pageOverhead)
         {
-            _cachedPagePackets = null;
             _lastPageGranulePos = granulePos = _reader.GranulePosition;
             _lastPageIsContinuation = isContinuation = (_reader.PageFlags & PageFlags.ContinuesPacket) != 0;
             _lastPageIsContinued = isContinued = _reader.IsContinued;
             _lastPagePacketCount = packetCount = _reader.PacketCount;
             _lastPageOverhead = pageOverhead = _reader.PageOverhead;
             _lastPageIndex = pageIndex;
+            // cache packets while the page is already loaded — avoids a second ReadPageAt in GetPagePackets
+            _cachedPagePackets = _reader.GetPackets();
         }
 
         public void SetEndOfStream()


### PR DESCRIPTION
## Summary

- Every seek read the target page from disk twice: once in `GetPage` (via `NormalizePacketIndex`) which cleared `_cachedPagePackets`, and again in `GetPagePackets` (called from `CreatePacket`) which found the cache empty
- Fix: call `_reader.GetPackets()` at the end of `ReadPageData` while the page is already loaded in the reader (lock is held), storing the result in `_cachedPagePackets`
- `GetPagePackets` now hits the cache on the first call after `GetPage` for the same page index

## Details

**Before:**
```
GetPage(n)        → ReadPageAt(offset)  ← read #1
                  → ReadPageData        → _cachedPagePackets = null
GetPagePackets(n) → cache miss
                  → ReadPageAt(offset)  ← read #2
                  → GetPackets()
```

**After:**
```
GetPage(n)        → ReadPageAt(offset)  ← read #1
                  → ReadPageData        → _cachedPagePackets = GetPackets()
GetPagePackets(n) → cache hit, return   ← no second read
```

`ReadPageData` is always called while `_reader.Lock()` is held, so calling `GetPackets()` there is safe.

## Test plan

- [x] All 51 unit tests pass (`dotnet test`)
- [x] `StreamPageReaderTests.GetPageThenGetPackets_ReadsPageFromDiskOnce` — asserts `ReadPageAt` call count is 1 after both `GetPage` and `GetPagePackets`
- [x] `StreamPageReaderTests.GetPagePackets_AfterGetPage_ReturnsCorrectData` — asserts cached packet data is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)