### PR TITLE
Bound NormalizePacketIndex walkback at FirstDataPageIndex

### DIFF
--- a/NVorbis.Tests/PacketProviderTests.cs
+++ b/NVorbis.Tests/PacketProviderTests.cs
@@ -1,0 +1,81 @@
+using NVorbis.Contracts;
+using NVorbis.Contracts.Ogg;
+using NVorbis.Ogg;
+using System;
+using Xunit;
+
+namespace NVorbis.Tests
+{
+    public class PacketProviderTests
+    {
+        /// <summary>
+        /// Two-page audio stream where the first audio packet spans both pages:
+        ///   page 1 (FDI) : isContinuation=false, isContinued=true,  packetCount=1, granulePos=-1
+        ///   page 2       : isContinuation=true,  isContinued=false, packetCount=1, granulePos=256
+        ///
+        /// NormalizePacketIndex walkback for (page=2, packet=0):
+        ///   pktIdx=0 &lt; 1 (isContinuation) → enter loop
+        ///   pgIdx(2) &gt; FDI(1)           → decrement to 1, read page 1
+        ///   pktIdx += 1 - 1 = 0         → no progress, still in loop
+        ///   pgIdx(1) &lt;= FDI(1)          → SNAP to (FDI, 0), return true
+        /// </summary>
+        private sealed class ContinuedFirstPacketReader : IStreamPageReader
+        {
+            public int FirstDataPageIndex => 1;
+            public int PageCount => 3;
+            public bool HasAllPages => true;
+            public long? MaxGranulePosition => 256;
+            public Contracts.IPacketProvider PacketProvider => null;
+
+            public int FindPage(long granulePos) => 2;
+
+            public bool GetPage(int pageIndex, out long granulePos, out bool isResync,
+                out bool isContinuation, out bool isContinued, out int packetCount, out int pageOverhead)
+            {
+                isResync = false;
+                pageOverhead = 27;
+                if (pageIndex == 1)
+                {
+                    granulePos = -1;
+                    isContinuation = false;
+                    isContinued = true;
+                    packetCount = 1;
+                    return true;
+                }
+                if (pageIndex == 2)
+                {
+                    granulePos = 256;
+                    isContinuation = true;
+                    isContinued = false;
+                    packetCount = 1;
+                    return true;
+                }
+                granulePos = 0;
+                isContinuation = false;
+                isContinued = false;
+                packetCount = 0;
+                return false;
+            }
+
+            public Memory<byte>[] GetPagePackets(int pageIndex) =>
+                new[] { new Memory<byte>(new byte[1]) };
+
+            public void AddPage() { }
+            public void SetEndOfStream() { }
+        }
+
+        [Fact]
+        public void SeekTo_WalkbackReachesFDI_SnapsToStreamBeginningInsteadOfThrowing()
+        {
+            var reader = new ContinuedFirstPacketReader();
+            var provider = new PacketProvider(reader, 0);
+
+            // Without the FDI bound, GetPage(0) returns false → NormalizePacketIndex
+            // returns false → SeekTo throws ArgumentOutOfRangeException.
+            // With the fix, the snap returns (FDI, 0) and SeekTo succeeds with granulePos=0.
+            var result = provider.SeekTo(128L, 1, _ => 256);
+
+            Assert.Equal(0L, result);
+        }
+    }
+}

--- a/NVorbis/Ogg/PacketProvider.cs
+++ b/NVorbis/Ogg/PacketProvider.cs
@@ -286,11 +286,21 @@ namespace NVorbis.Ogg
 
             var pgIdx = pageIndex;
             var pktIdx = packetIndex;
+            var firstDataPage = _reader.FirstDataPageIndex;
 
             while (pktIdx < (isContinuation ? 1: 0))
             {
                 // can't merge across resync
                 if (isContinuation && isResync) return false;
+
+                // walked back to the first audio page without resolving — snap to stream
+                // beginning, consistent with the SeekTo first-page shortcut
+                if (pgIdx <= firstDataPage)
+                {
+                    pageIndex = firstDataPage;
+                    packetIndex = 0;
+                    return true;
+                }
 
                 // get the previous packet
                 var wasContinuation = isContinuation;


### PR DESCRIPTION
## Summary

- `NormalizePacketIndex` walked backward through pages with no lower bound — a stream where every page holds exactly one continued packet caused O(N) page reads, eventually returning `false` (page index goes negative) and causing `SeekTo` to throw `ArgumentOutOfRangeException`
- Fix: before decrementing `pgIdx`, check `pgIdx <= firstDataPage`; if so, snap to `(FDI, 0)` and return `true` — consistent with the `SeekTo` first-page shortcut that already snaps early seeks to the stream beginning
- Walk is now bounded to at most `pageIndex - FirstDataPageIndex` iterations

## Details

The pathological case: every page has `packetCount = 1` and `isContinued = true`, so each iteration of the loop adds `1 - 1 = 0` to `pktIdx` with no progress. With the fix, the walk terminates at FDI rather than page -1.

Snapping to `(FDI, 0)` is correct: if the pre-roll packet's origin is at or before the first data page, the first audio packet is as far back as we can go, which is exactly what the `SeekTo` first-page shortcut already guarantees.

## Test plan

- [ ] All 52 unit tests pass (`dotnet test`)
- [ ] `PacketProviderTests.SeekTo_WalkbackReachesFDI_SnapsToStreamBeginningInsteadOfThrowing` — mock stream with a single audio packet spanning two pages; verifies `SeekTo` returns `0` (snapped granulePos) rather than throwing `ArgumentOutOfRangeException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)