### PR TITLE
fix: dead null check, Dispose idempotency, Codebook idxDiv overflow

### DIFF
--- a/NVorbis/Codebook.cs
+++ b/NVorbis/Codebook.cs
@@ -249,10 +249,10 @@ namespace NVorbis
                 for (var idx = 0; idx < Entries; idx++)
                 {
                     var last = 0.0;
-                    var idxDiv = 1;
+                    var idxDiv = 1L;
                     for (var i = 0; i < Dimensions; i++)
                     {
-                        var moff = (idx / idxDiv) % lookupValueCount;
+                        var moff = (int)((idx / idxDiv) % lookupValueCount);
                         var value = (float)multiplicands[moff] * deltaValue + minValue + last;
                         lookupTable[idx * Dimensions + i] = (float)value;
 

--- a/NVorbis/StreamDecoder.cs
+++ b/NVorbis/StreamDecoder.cs
@@ -321,7 +321,6 @@ namespace NVorbis
         /// <remarks>The data populated into <paramref name="buffer"/> is interleaved by channel in normal PCM fashion: Left, Right, Left, Right, Left, Right</remarks>
         public int Read(Span<float> buffer, int offset, int count)
         {
-            if (buffer == null) throw new ArgumentNullException(nameof(buffer));
             if (offset < 0 || offset + count > buffer.Length) throw new ArgumentOutOfRangeException(nameof(offset));
             if (count % _channels != 0) throw new ArgumentOutOfRangeException(nameof(count), "Must be a multiple of Channels!");
             if (_packetProvider == null) throw new ObjectDisposedException(nameof(StreamDecoder));

--- a/NVorbis/VorbisReader.cs
+++ b/NVorbis/VorbisReader.cs
@@ -19,6 +19,7 @@ namespace NVorbis
         private readonly bool _closeOnDispose;
 
         private IStreamDecoder _streamDecoder;
+        private bool _disposed;
 
         /// <summary>
         /// Raised when a new stream has been encountered in the file or container.
@@ -99,22 +100,19 @@ namespace NVorbis
         /// </summary>
         public void Dispose()
         {
-            if (_decoders != null)
-            {
-                foreach (var decoder in _decoders)
-                {
-                    decoder.Dispose();
-                }
-                _decoders.Clear();
-            }
+            if (_disposed) return;
+            _disposed = true;
 
-            if (_containerReader != null)
+            foreach (var decoder in _decoders)
             {
-                _containerReader.NewStreamCallback = null;
-                if (_closeOnDispose)
-                {
-                    _containerReader.Dispose();
-                }
+                decoder.Dispose();
+            }
+            _decoders.Clear();
+
+            _containerReader.NewStreamCallback = null;
+            if (_closeOnDispose)
+            {
+                _containerReader.Dispose();
             }
         }
 


### PR DESCRIPTION
## Summary

Three independent correctness fixes.

- **`StreamDecoder.Read(Span<float>, int, int)`** — remove the `if (buffer == null)` guard. `Span<float>` is a struct; the compiler prevents null assignment, so the check was unreachable dead code that misled readers.

- **`VorbisReader.Dispose`** — add a `_disposed` flag. The previous implementation used `if (_decoders != null)` / `if (_containerReader != null)` as guards, but both fields are `readonly` and always non-null after construction, so a second `Dispose()` call would iterate the (cleared) decoder list again and invoke `_containerReader.Dispose()` a second time.

- **`Codebook.InitLookupTable`** — change `idxDiv` from `int` to `long`. The loop multiplies `idxDiv *= lookupValueCount` once per dimension; for codebooks with Dimensions ≥ 10 and `lookupValueCount > 1` the product overflows `int`, producing a wrong `moff` array index and silently corrupting the lookup table.

## Test plan

- [x] All 137 tests pass (`dotnet test`)
- [x] `Dispose_CalledTwice_DoesNotThrow` in `LifecycleTests` covers the Dispose fix
- [x] `VorbisReaderTests` Span overload tests cover the `Read(Span<float>)` path
- [x] Existing full-decode tests exercise codebook lookup paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)