### PR TITLE
api: Read(Span<float>) on IStreamDecoder, OpenAsync factory, threading docs

### DIFF
--- a/NVorbis/Contracts/IStreamDecoder.cs
+++ b/NVorbis/Contracts/IStreamDecoder.cs
@@ -96,11 +96,20 @@ namespace NVorbis.Contracts
         /// Reads samples into the specified buffer.
         /// </summary>
         /// <param name="buffer">The buffer to read the samples into.</param>
+        /// <returns>The number of samples read into the buffer.</returns>
+        /// <remarks>The data populated into <paramref name="buffer"/> is interleaved by channel in normal PCM fashion: Left, Right, Left, Right, Left, Right</remarks>
+        int Read(Span<float> buffer);
+
+        /// <summary>
+        /// Reads samples into the specified buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to read the samples into.</param>
         /// <param name="offset">The index to start reading samples into the buffer.</param>
         /// <param name="count">The number of samples that should be read into the buffer.  Must be a multiple of <see cref="Channels"/>.</param>
         /// <returns>The number of samples read into the buffer.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the buffer is too small or <paramref name="offset"/> is less than zero.</exception>
         /// <remarks>The data populated into <paramref name="buffer"/> is interleaved by channel in normal PCM fashion: Left, Right, Left, Right, Left, Right</remarks>
+        [Obsolete("Use Read(Span<float>) instead.")]
         int Read(Span<float> buffer, int offset, int count);
     }
 }

--- a/NVorbis/StreamDecoder.cs
+++ b/NVorbis/StreamDecoder.cs
@@ -314,29 +314,20 @@ namespace NVorbis
         /// Reads samples into the specified buffer.
         /// </summary>
         /// <param name="buffer">The buffer to read the samples into.</param>
-        /// <param name="offset">The index to start reading samples into the buffer.</param>
-        /// <param name="count">The number of samples that should be read into the buffer.  Must be a multiple of <see cref="Channels"/>.</param>
         /// <returns>The number of samples read into the buffer.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown when the buffer is too small or <paramref name="offset"/> is less than zero.</exception>
         /// <remarks>The data populated into <paramref name="buffer"/> is interleaved by channel in normal PCM fashion: Left, Right, Left, Right, Left, Right</remarks>
-        public int Read(Span<float> buffer, int offset, int count)
+        public int Read(Span<float> buffer)
         {
-            if (offset < 0 || offset + count > buffer.Length) throw new ArgumentOutOfRangeException(nameof(offset));
-            if (count % _channels != 0) throw new ArgumentOutOfRangeException(nameof(count), "Must be a multiple of Channels!");
             if (_packetProvider == null) throw new ObjectDisposedException(nameof(StreamDecoder));
 
             // if the caller didn't ask for any data, bail early
-            if (count == 0)
+            if (buffer.IsEmpty)
             {
                 return 0;
             }
 
-            // save off value to track when we're done with the request
-            var idx = offset;
-            var tgt = offset + count;
-
-            // try to fill the buffer; drain the last buffer if EOS, resync, bad packet, or parameter change
-            while (idx < tgt)
+            int count = 0;
+            while (buffer.Length >= _channels)
             {
                 // if we don't have any more valid data in the current packet, read in the next packet
                 if (_prevPacketStart == _prevPacketEnd)
@@ -350,7 +341,7 @@ namespace NVorbis
                         break;
                     }
 
-                    if (!ReadNextPacket((idx - offset) / _channels, out var samplePosition))
+                    if (!ReadNextPacket(count / _channels, out var samplePosition))
                     {
                         // drain the current packet (the windowing will fade it out)
                         _prevPacketEnd = _prevPacketStop;
@@ -360,27 +351,27 @@ namespace NVorbis
                     if (samplePosition.HasValue && !_hasPosition)
                     {
                         _hasPosition = true;
-                        _currentPosition = samplePosition.Value - (_prevPacketEnd - _prevPacketStart) - (idx - offset) / _channels;
+                        _currentPosition = samplePosition.Value - (_prevPacketEnd - _prevPacketStart) - count / _channels;
                     }
                 }
 
                 // we read out the valid samples from the previous packet
-                var copyLen = Math.Min((tgt - idx) / _channels, _prevPacketEnd - _prevPacketStart);
+                var copyLen = Math.Min(buffer.Length / _channels, _prevPacketEnd - _prevPacketStart) * _channels;
                 if (copyLen > 0)
                 {
+                    int written;
                     if (ClipSamples)
                     {
-                        idx += ClippingCopyBuffer(buffer, idx, copyLen);
+                        written = ClippingCopyBuffer(buffer.Slice(0, copyLen));
                     }
                     else
                     {
-                        idx += CopyBuffer(buffer, idx, copyLen);
+                        written = CopyBuffer(buffer.Slice(0, copyLen));
                     }
+                    count += written;
+                    buffer = buffer.Slice(written);
                 }
             }
-
-            // update the count of floats written
-            count = idx - offset;
 
             // update the position
             _currentPosition += count / _channels;
@@ -389,30 +380,49 @@ namespace NVorbis
             return count;
         }
 
-        private int ClippingCopyBuffer(Span<float> target, int targetIndex, int count)
+        /// <summary>
+        /// Reads samples into the specified buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to read the samples into.</param>
+        /// <param name="offset">The index to start reading samples into the buffer.</param>
+        /// <param name="count">The number of samples that should be read into the buffer.  Must be a multiple of <see cref="Channels"/>.</param>
+        /// <returns>The number of samples read into the buffer.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the buffer is too small or <paramref name="offset"/> is less than zero.</exception>
+        /// <remarks>The data populated into <paramref name="buffer"/> is interleaved by channel in normal PCM fashion: Left, Right, Left, Right, Left, Right</remarks>
+        [Obsolete("Use Read(Span<float>) instead.")]
+        public int Read(Span<float> buffer, int offset, int count)
         {
-            var idx = targetIndex;
-            for (; count > 0; _prevPacketStart++, count--)
+            if (offset < 0 || offset + count > buffer.Length) throw new ArgumentOutOfRangeException(nameof(offset));
+            if (count % _channels != 0) throw new ArgumentOutOfRangeException(nameof(count), "Must be a multiple of Channels!");
+            return Read(buffer.Slice(offset, count));
+        }
+
+        private int ClippingCopyBuffer(Span<float> target)
+        {
+            var idx = 0;
+            while (idx < target.Length)
             {
                 for (var ch = 0; ch < _channels; ch++)
                 {
                     target[idx++] = Utils.ClipValue(_prevPacketBuf[ch][_prevPacketStart], ref _hasClipped);
                 }
+                ++_prevPacketStart;
             }
-            return idx - targetIndex;
+            return idx;
         }
 
-        private int CopyBuffer(Span<float> target, int targetIndex, int count)
+        private int CopyBuffer(Span<float> target)
         {
-            var idx = targetIndex;
-            for (; count > 0; _prevPacketStart++, count--)
+            var idx = 0;
+            while (idx < target.Length)
             {
                 for (var ch = 0; ch < _channels; ch++)
                 {
                     target[idx++] = _prevPacketBuf[ch][_prevPacketStart];
                 }
+                ++_prevPacketStart;
             }
-            return idx - targetIndex;
+            return idx;
         }
 
         private bool ReadNextPacket(int bufferedSamples, out long? samplePosition)

--- a/NVorbis/VorbisReader.cs
+++ b/NVorbis/VorbisReader.cs
@@ -345,7 +345,7 @@ namespace NVorbis
             count -= count % _streamDecoder.Channels;
             if (count > 0)
             {
-                return _streamDecoder.Read(buffer, offset, count);
+                return _streamDecoder.Read(new Span<float>(buffer, offset, count));
             }
             return 0;
         }
@@ -359,13 +359,7 @@ namespace NVorbis
         /// <remarks>The data populated into <paramref name="buffer"/> is interleaved by channel in normal PCM fashion: Left, Right, Left, Right, Left, Right</remarks>
         public int ReadSamples(Span<float> buffer)
         {
-            // don't allow non-aligned reads (always on a full sample boundary!)
-            int count = buffer.Length - buffer.Length % _streamDecoder.Channels;
-            if (count > 0)
-            {
-                return _streamDecoder.Read(buffer, 0, count);
-            }
-            return 0;
+            return _streamDecoder.Read(buffer);
         }
 
         /// <summary>

--- a/NVorbis/VorbisReader.cs
+++ b/NVorbis/VorbisReader.cs
@@ -3,6 +3,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace NVorbis
 {
@@ -71,6 +73,35 @@ namespace NVorbis
             _containerReader = containerReader;
             _streamDecoder = _decoders[0];
         }
+
+        /// <summary>
+        /// Opens the specified file on a background thread and returns a <see cref="VorbisReader"/> once the stream headers have been read.
+        /// </summary>
+        /// <param name="fileName">The file to read from.</param>
+        /// <param name="cancellationToken">A token to cancel the operation.</param>
+        /// <returns>A <see cref="Task{VorbisReader}"/> that completes when the instance is ready to decode.</returns>
+        /// <remarks>
+        /// Use this overload from UI or async contexts to avoid blocking while the file is opened and headers are parsed.
+        /// Once the returned instance is ready, call <see cref="ReadSamples(float[], int, int)"/> or
+        /// <see cref="ReadSamples(Span{float})"/> on a single dedicated background thread for the lifetime of the instance.
+        /// </remarks>
+        public static Task<VorbisReader> OpenAsync(string fileName, CancellationToken cancellationToken = default)
+            => Task.Run(() => new VorbisReader(fileName), cancellationToken);
+
+        /// <summary>
+        /// Initializes a <see cref="VorbisReader"/> from the specified stream on a background thread and returns it once the stream headers have been read.
+        /// </summary>
+        /// <param name="stream">The <see cref="Stream"/> to read from.</param>
+        /// <param name="closeOnDispose"><see langword="true"/> to take ownership and close the stream when disposed, otherwise <see langword="false"/>.</param>
+        /// <param name="cancellationToken">A token to cancel the operation.</param>
+        /// <returns>A <see cref="Task{VorbisReader}"/> that completes when the instance is ready to decode.</returns>
+        /// <remarks>
+        /// Use this overload from UI or async contexts to avoid blocking while stream headers are parsed.
+        /// Once the returned instance is ready, call <see cref="ReadSamples(float[], int, int)"/> or
+        /// <see cref="ReadSamples(Span{float})"/> on a single dedicated background thread for the lifetime of the instance.
+        /// </remarks>
+        public static Task<VorbisReader> OpenAsync(Stream stream, bool closeOnDispose = true, CancellationToken cancellationToken = default)
+            => Task.Run(() => new VorbisReader(stream, closeOnDispose), cancellationToken);
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         [Obsolete("Use \"new StreamDecoder(Contracts.IPacketProvider)\" and the container's NewStreamCallback or Streams property instead.", true)]
@@ -338,7 +369,15 @@ namespace NVorbis
         /// <param name="count">The number of samples that should be read into the buffer.</param>
         /// <returns>The number of floats read into the buffer.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the buffer is too small or <paramref name="offset"/> is less than zero.</exception>
-        /// <remarks>The data populated into <paramref name="buffer"/> is interleaved by channel in normal PCM fashion: Left, Right, Left, Right, Left, Right</remarks>
+        /// <remarks>
+        /// The data populated into <paramref name="buffer"/> is interleaved by channel in normal PCM fashion: Left, Right, Left, Right, Left, Right.
+        /// <para>
+        /// This method is not thread-safe.  All calls to <see cref="ReadSamples(float[], int, int)"/>, <see cref="ReadSamples(Span{float})"/>,
+        /// and <see cref="SeekTo(long, SeekOrigin)"/> on a given instance must be made from a single thread.
+        /// To avoid blocking a UI or async context, open the instance with <see cref="OpenAsync(string, CancellationToken)"/>
+        /// and call this method from a dedicated background thread.
+        /// </para>
+        /// </remarks>
         public int ReadSamples(float[] buffer, int offset, int count)
         {
             // don't allow non-aligned reads (always on a full sample boundary!)
@@ -355,8 +394,15 @@ namespace NVorbis
         /// </summary>
         /// <param name="buffer">The buffer to read the samples into.</param>
         /// <returns>The number of floats read into the buffer.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown when the buffer is too small.</exception>
-        /// <remarks>The data populated into <paramref name="buffer"/> is interleaved by channel in normal PCM fashion: Left, Right, Left, Right, Left, Right</remarks>
+        /// <remarks>
+        /// The data populated into <paramref name="buffer"/> is interleaved by channel in normal PCM fashion: Left, Right, Left, Right, Left, Right.
+        /// <para>
+        /// This method is not thread-safe.  All calls to <see cref="ReadSamples(float[], int, int)"/>, <see cref="ReadSamples(Span{float})"/>,
+        /// and <see cref="SeekTo(long, SeekOrigin)"/> on a given instance must be made from a single thread.
+        /// To avoid blocking a UI or async context, open the instance with <see cref="OpenAsync(string, CancellationToken)"/>
+        /// and call this method from a dedicated background thread.
+        /// </para>
+        /// </remarks>
         public int ReadSamples(Span<float> buffer)
         {
             return _streamDecoder.Read(buffer);


### PR DESCRIPTION
## Summary

- **`IStreamDecoder.Read(Span<float>)`** — new canonical decode method. Handles channel alignment internally; callers no longer need to compute an aligned count or supply offset/length. The decode loop advances a local `Span<float>` slice rather than tracking an integer index.
- **`IStreamDecoder.Read(Span<float>, int, int)`** — marked `[Obsolete]` on both interface and implementation. Now validates parameters and delegates to `Read(Span<float>)` via `Span.Slice`.
- **`VorbisReader.ReadSamples` call sites** — updated to call `Read(Span<float>)` directly; no obsolete-call warnings in the library itself.
- **`VorbisReader.OpenAsync`** — two static factory overloads (`string` and `Stream`) that construct and initialise a `VorbisReader` on the thread pool via `Task.Run`. Opening reads three Ogg header packets synchronously; these factories allow UI and async callers to await that work without blocking.
- **`ReadSamples` XML docs** — both overloads now state explicitly that the instance is not thread-safe, all decode and seek calls must come from a single thread, and `OpenAsync` is the recommended entry point when background execution is needed.

## Test plan

- [x] All 137 tests pass (`dotnet test`)
- [x] No CS0618 warnings in the library itself
- [x] `VorbisReaderTests` Span overload tests exercise the new `Read(Span<float>)` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)