### PR TITLE
fix: reliability — MDCT double precision, Floor0 bark scale precision, Codebook null safety

### DIFF
--- a/NVorbis.Tests/Floor0Tests.cs
+++ b/NVorbis.Tests/Floor0Tests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace NVorbis.Tests
+{
+    public class Floor0Tests
+    {
+        static readonly Type _floor0Type =
+            typeof(VorbisReader).Assembly.GetType("NVorbis.Floor0")!;
+
+        static readonly MethodInfo _toBark =
+            _floor0Type.GetMethod("toBARK", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        static readonly MethodInfo _synthBark =
+            _floor0Type.GetMethod("SynthesizeBarkCurve", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        static double ToBark(double lsp) =>
+            (double)_toBark.Invoke(null, new object[] { lsp })!;
+
+        static object MakeFloor0(int rate, int barkMapSize)
+        {
+            var instance = Activator.CreateInstance(_floor0Type, nonPublic: true)!;
+            _floor0Type.GetField("_rate", BindingFlags.NonPublic | BindingFlags.Instance)!
+                       .SetValue(instance, rate);
+            _floor0Type.GetField("_bark_map_size", BindingFlags.NonPublic | BindingFlags.Instance)!
+                       .SetValue(instance, barkMapSize);
+            return instance;
+        }
+
+        static int[] SynthesizeBarkCurve(object instance, int n) =>
+            (int[])_synthBark.Invoke(instance, new object[] { n })!;
+
+        // ── toBARK precision ────────────────────────────────────────────────
+
+        [Fact]
+        public void ToBark_ReturnType_IsDouble()
+        {
+            Assert.Equal(typeof(double), _toBark.ReturnType);
+        }
+
+        [Fact]
+        public void ToBark_Result_HasSubFloatPrecision()
+        {
+            // If toBARK still returned float the double value would equal its own
+            // float cast. A true double return carries bits below float precision.
+            double val = ToBark(22050.0);
+            Assert.NotEqual((double)(float)val, val);
+        }
+
+        [Fact]
+        public void ToBark_HalfNyquist_IsPositive()
+        {
+            Assert.True(ToBark(11025.0) > 0.0);
+        }
+
+        [Fact]
+        public void ToBark_Zero_IsZero()
+        {
+            Assert.Equal(0.0, ToBark(0.0));
+        }
+
+        [Fact]
+        public void ToBark_IsMonotonicallyIncreasing()
+        {
+            Assert.True(ToBark(11025.0) < ToBark(22050.0));
+        }
+
+        // ── SynthesizeBarkCurve ─────────────────────────────────────────────
+
+        [Fact]
+        public void SynthesizeBarkCurve_TerminatorIsMinusOne()
+        {
+            var floor0 = MakeFloor0(rate: 44100, barkMapSize: 256);
+            int n = 512;
+            int[] map = SynthesizeBarkCurve(floor0, n);
+            Assert.Equal(-1, map[n]);
+        }
+
+        [Fact]
+        public void SynthesizeBarkCurve_BinsAreNonDecreasing()
+        {
+            var floor0 = MakeFloor0(rate: 44100, barkMapSize: 256);
+            int[] map = SynthesizeBarkCurve(floor0, 512);
+            for (int i = 1; i < 511; i++)
+            {
+                Assert.True(map[i] >= map[i - 1],
+                    $"map[{i}]={map[i]} < map[{i - 1}]={map[i - 1]}");
+            }
+        }
+
+        [Fact]
+        public void SynthesizeBarkCurve_AllBinsInRange()
+        {
+            int barkMapSize = 256;
+            var floor0 = MakeFloor0(rate: 44100, barkMapSize: barkMapSize);
+            int[] map = SynthesizeBarkCurve(floor0, 512);
+            for (int i = 0; i < 511; i++)
+            {
+                Assert.InRange(map[i], 0, barkMapSize - 1);
+            }
+        }
+
+        [Fact]
+        public void SynthesizeBarkCurve_FirstBinIsZero()
+        {
+            var floor0 = MakeFloor0(rate: 44100, barkMapSize: 256);
+            int[] map = SynthesizeBarkCurve(floor0, 512);
+            Assert.Equal(0, map[0]);
+        }
+
+        [Fact]
+        public void SynthesizeBarkCurve_LastDataBinIsMaxBark()
+        {
+            int barkMapSize = 256;
+            var floor0 = MakeFloor0(rate: 44100, barkMapSize: barkMapSize);
+            int n = 512;
+            int[] map = SynthesizeBarkCurve(floor0, n);
+            Assert.Equal(barkMapSize - 1, map[n - 2]);
+        }
+    }
+}

--- a/NVorbis/Codebook.cs
+++ b/NVorbis/Codebook.cs
@@ -147,12 +147,12 @@ namespace NVorbis
                 }
 
                 int[] values = null;
-                int[] codewords = null;
+                int[] codewords;
                 if (!sparse)
                 {
                     codewords = new int[Entries];
                 }
-                else if (sortedCount != 0)
+                else
                 {
                     codewordLengths = new int[sortedCount];
                     codewords = new int[sortedCount];

--- a/NVorbis/Floor0.cs
+++ b/NVorbis/Floor0.cs
@@ -66,21 +66,21 @@ namespace NVorbis
 
         int[] SynthesizeBarkCurve(int n)
         {
-            var scale = _bark_map_size / toBARK(_rate / 2);
+            var scale = _bark_map_size / toBARK(_rate / 2.0);
 
             var map = new int[n + 1];
 
             for (int i = 0; i < n - 1; i++)
             {
-                map[i] = Math.Min(_bark_map_size - 1, (int)Math.Floor(toBARK((_rate / 2f) / n * i) * scale));
+                map[i] = Math.Min(_bark_map_size - 1, (int)Math.Floor(toBARK((_rate / 2.0) / n * i) * scale));
             }
             map[n] = -1;
             return map;
         }
 
-        static float toBARK(double lsp)
+        static double toBARK(double lsp)
         {
-            return (float)(13.1 * Math.Atan(0.00074 * lsp) + 2.24 * Math.Atan(0.0000000185 * lsp * lsp) + .0001 * lsp);
+            return 13.1 * Math.Atan(0.00074 * lsp) + 2.24 * Math.Atan(0.0000000185 * lsp * lsp) + .0001 * lsp;
         }
 
         float[] SynthesizeWDelMap(int n)

--- a/NVorbis/Mdct.cs
+++ b/NVorbis/Mdct.cs
@@ -6,8 +6,6 @@ namespace NVorbis
 {
     class Mdct : IMdct
     {
-        const float M_PI = 3.14159265358979323846264f;
-
         readonly object _cacheLock = new object();
         Dictionary<int, MdctImpl> _setupCache = new Dictionary<int, MdctImpl>();
 
@@ -51,15 +49,15 @@ namespace NVorbis
                 int k, k2;
                 for (k = k2 = 0; k < _n4; ++k, k2 += 2)
                 {
-                    _a[k2] = (float)Math.Cos(4 * k * M_PI / n);
-                    _a[k2 + 1] = (float)-Math.Sin(4 * k * M_PI / n);
-                    _b[k2] = (float)Math.Cos((k2 + 1) * M_PI / n / 2) * .5f;
-                    _b[k2 + 1] = (float)Math.Sin((k2 + 1) * M_PI / n / 2) * .5f;
+                    _a[k2] = (float)Math.Cos(4 * k * Math.PI / n);
+                    _a[k2 + 1] = (float)-Math.Sin(4 * k * Math.PI / n);
+                    _b[k2] = (float)Math.Cos((k2 + 1) * Math.PI / n / 2) * .5f;
+                    _b[k2 + 1] = (float)Math.Sin((k2 + 1) * Math.PI / n / 2) * .5f;
                 }
                 for (k = k2 = 0; k < _n8; ++k, k2 += 2)
                 {
-                    _c[k2] = (float)Math.Cos(2 * (k2 + 1) * M_PI / n);
-                    _c[k2 + 1] = (float)-Math.Sin(2 * (k2 + 1) * M_PI / n);
+                    _c[k2] = (float)Math.Cos(2 * (k2 + 1) * Math.PI / n);
+                    _c[k2 + 1] = (float)-Math.Sin(2 * (k2 + 1) * Math.PI / n);
                 }
 
                 // now, calc the bit reverse table

--- a/NVorbis/Mdct.cs
+++ b/NVorbis/Mdct.cs
@@ -49,15 +49,15 @@ namespace NVorbis
                 int k, k2;
                 for (k = k2 = 0; k < _n4; ++k, k2 += 2)
                 {
-                    _a[k2] = (float)Math.Cos(4 * k * Math.PI / n);
-                    _a[k2 + 1] = (float)-Math.Sin(4 * k * Math.PI / n);
+                    _a[k2] = (float)Math.Cos(4.0 * k * Math.PI / n);
+                    _a[k2 + 1] = (float)-Math.Sin(4.0 * k * Math.PI / n);
                     _b[k2] = (float)Math.Cos((k2 + 1) * Math.PI / n / 2) * .5f;
                     _b[k2 + 1] = (float)Math.Sin((k2 + 1) * Math.PI / n / 2) * .5f;
                 }
                 for (k = k2 = 0; k < _n8; ++k, k2 += 2)
                 {
-                    _c[k2] = (float)Math.Cos(2 * (k2 + 1) * Math.PI / n);
-                    _c[k2 + 1] = (float)-Math.Sin(2 * (k2 + 1) * Math.PI / n);
+                    _c[k2] = (float)Math.Cos(2.0 * (k2 + 1) * Math.PI / n);
+                    _c[k2 + 1] = (float)-Math.Sin(2.0 * (k2 + 1) * Math.PI / n);
                 }
 
                 // now, calc the bit reverse table


### PR DESCRIPTION
## Summary

Three independent correctness and reliability fixes.

### MDCT twiddle factors at double precision (`Mdct.cs`)

`M_PI` was `const float`, causing all six twiddle-factor arguments to be evaluated in float arithmetic before reaching `Math.Cos`/`Math.Sin`. With float `M_PI` the constant carries ~1.2e-7 relative error, and `int * float` promotion keeps the entire expression at ~24-bit precision before the trig call. Replace all six `M_PI` references with `Math.PI` (a `double` constant) and remove the field. `int * double` promotes to double, so each argument is computed at 53-bit precision; only the final `(float)` cast narrows the stored twiddle value.

### Floor0 bark scale and map at double precision (`Floor0.cs`)

`toBARK` returned `float` despite computing entirely in `double` internally, making `scale` (`_bark_map_size / toBARK(...)`) a float and causing `Math.Floor` on the per-bin argument to operate at float precision. Three changes: `toBARK` return type `float` → `double`; `_rate / 2` → `_rate / 2.0` for the scale computation; `_rate / 2f` → `_rate / 2.0` in the per-bin loop. `scale` is now `double`; bark bin assignments computed at 53-bit precision throughout.

### Codebook sparse codewords definite assignment (`Codebook.cs`)

`codewords` was declared `null` and only allocated in two of three branches (`if (!sparse)` and `else if (sortedCount != 0)`), leaving it null when `sparse && sortedCount == 0`. That case is unreachable (total == 0 → maxLen == -1 → outer block not entered), but the safety depended on a non-obvious cross-variable invariant and static analysers correctly flagged the potential `NullReferenceException`. Collapsed `else if (sortedCount != 0)` to `else` so both branches assign `codewords` and the compiler can verify definite assignment.

## Test plan

- [ ] All 147 tests pass (`dotnet test`)
- [ ] `Floor0Tests`: `ToBark_ReturnType_IsDouble`, `ToBark_Result_HasSubFloatPrecision`, bark curve monotonicity and range (10 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)