### PR TITLE
fix: review follow-ups (boxing, stat undercount, read guard, message)

### DIFF
--- a/NVorbis.Tests/ExtensionsTests.cs
+++ b/NVorbis.Tests/ExtensionsTests.cs
@@ -1,0 +1,88 @@
+using NVorbis.Contracts;
+using System;
+using Xunit;
+
+namespace NVorbis.Tests
+{
+    public class ExtensionsTests
+    {
+        private class ByteArrayPacket : DataPacket
+        {
+            private readonly byte[] _data;
+            private int _pos;
+            public ByteArrayPacket(byte[] data) => _data = data;
+            protected override int TotalBits => _data.Length * 8;
+            protected override int ReadNextByte() => _pos < _data.Length ? _data[_pos++] : -1;
+        }
+
+        // ── Read zero-count edge cases ───────────────────────────────────────
+
+        [Fact]
+        public void Read_ZeroCountAtBufferEnd_ReturnsZero()
+        {
+            IPacket packet = new ByteArrayPacket(new byte[] { 0x01 });
+            var buf = new byte[4];
+            // index == buffer.Length with count 0 is a valid no-op read
+            Assert.Equal(0, packet.Read(buf, buf.Length, 0));
+        }
+
+        [Fact]
+        public void Read_ZeroCountEmptyBuffer_ReturnsZero()
+        {
+            IPacket packet = new ByteArrayPacket(new byte[] { 0x01 });
+            Assert.Equal(0, packet.Read(Array.Empty<byte>(), 0, 0));
+        }
+
+        [Fact]
+        public void Read_NegativeIndex_Throws()
+        {
+            IPacket packet = new ByteArrayPacket(new byte[] { 0x01 });
+            Assert.Throws<ArgumentOutOfRangeException>(() => packet.Read(new byte[4], -1, 0));
+        }
+
+        [Fact]
+        public void Read_CountExceedsBuffer_Throws()
+        {
+            IPacket packet = new ByteArrayPacket(new byte[] { 0x01 });
+            Assert.Throws<ArgumentOutOfRangeException>(() => packet.Read(new byte[4], 2, 3));
+        }
+
+        [Fact]
+        public void Read_CopiesBytes()
+        {
+            IPacket packet = new ByteArrayPacket(new byte[] { 0xDE, 0xAD, 0xBE, 0xEF });
+            var buf = new byte[4];
+            Assert.Equal(4, packet.Read(buf, 0, 4));
+            Assert.Equal(new byte[] { 0xDE, 0xAD, 0xBE, 0xEF }, buf);
+        }
+
+        // ── ReadBytes ────────────────────────────────────────────────────────
+
+        [Fact]
+        public void ReadBytes_Zero_ReturnsEmptyArray()
+        {
+            // previously threw ArgumentOutOfRangeException because the guard rejected index == buffer.Length
+            IPacket packet = new ByteArrayPacket(new byte[] { 0x01 });
+            Assert.Empty(packet.ReadBytes(0));
+        }
+
+        [Fact]
+        public void ReadBytes_TruncatedStream_ReturnsShortArray()
+        {
+            IPacket packet = new ByteArrayPacket(new byte[] { 0x11, 0x22 });
+            // ask for more than exist; result is trimmed to what was available
+            var result = packet.ReadBytes(5);
+            Assert.Equal(new byte[] { 0x11, 0x22 }, result);
+        }
+
+        // ── flag accessors (boxing-free GetFlag) ─────────────────────────────
+
+        [Fact]
+        public void Flags_AreIndependent()
+        {
+            var packet = new ByteArrayPacket(new byte[] { 0x00 }) { IsResync = true, IsEndOfStream = false };
+            Assert.True(packet.IsResync);
+            Assert.False(packet.IsEndOfStream);
+        }
+    }
+}

--- a/NVorbis/DataPacket.cs
+++ b/NVorbis/DataPacket.cs
@@ -108,7 +108,8 @@ namespace NVorbis
         /// </summary>
         abstract protected int TotalBits { get; }
 
-        bool GetFlag(PacketFlags flag) => _packetFlags.HasFlag(flag);
+        // bitwise test instead of Enum.HasFlag, which boxes on .NET Framework; this runs per-packet
+        bool GetFlag(PacketFlags flag) => (_packetFlags & flag) == flag;
 
         void SetFlag(PacketFlags flag, bool value)
         {

--- a/NVorbis/Extensions.cs
+++ b/NVorbis/Extensions.cs
@@ -18,7 +18,7 @@ namespace NVorbis
         /// <returns>The number of bytes actually read into the buffer.</returns>
         public static int Read(this IPacket packet, byte[] buffer, int index, int count)
         {
-            if (index < 0 || index >= buffer.Length) throw new ArgumentOutOfRangeException(nameof(index));
+            if (index < 0) throw new ArgumentOutOfRangeException(nameof(index));
             if (count < 0 || index + count > buffer.Length) throw new ArgumentOutOfRangeException(nameof(count));
             for (int i = 0; i < count; i++)
             {

--- a/NVorbis/StreamDecoder.cs
+++ b/NVorbis/StreamDecoder.cs
@@ -475,6 +475,17 @@ namespace NVorbis
 
         private float[][] DecodeNextPacket(out int packetStartindex, out int packetValidLength, out int packetTotalLength, out bool isEndOfStream, out long? samplePosition, out int bitsRead, out int bitsRemaining, out int containerOverheadBits)
         {
+            // initialize the outputs up front so the bad/short/non-audio packet paths can report real
+            // bit counts to the stats without being clobbered by a trailing reset block
+            packetStartindex = 0;
+            packetValidLength = 0;
+            packetTotalLength = 0;
+            isEndOfStream = false;
+            samplePosition = null;
+            bitsRead = 0;
+            bitsRemaining = 0;
+            containerOverheadBits = 0;
+
             IPacket packet = null;
             try
             {
@@ -525,13 +536,6 @@ namespace NVorbis
                         bitsRemaining = packet.BitsRead + packet.BitsRemaining;
                     }
                 }
-                packetStartindex = 0;
-                packetValidLength = 0;
-                packetTotalLength = 0;
-                samplePosition = null;
-                bitsRead = 0;
-                bitsRemaining = 0;
-                containerOverheadBits = 0;
                 return null;
             }
             finally
@@ -636,7 +640,7 @@ namespace NVorbis
                 ResetDecoder();
                 // we'll use this to force ReadSamples to fail to read
                 _eosFound = true;
-                throw new InvalidOperationException("Could not read pre-roll packet!  Try seeking again prior to reading more samples.");
+                throw new InvalidOperationException("Could not read seek packet!  Try seeking again prior to reading more samples.");
             }
 
             // adjust our indexes to match what we want


### PR DESCRIPTION
Fixes from a correctness/reliability/performance pass over the decoder.

## Performance

- **`DataPacket.GetFlag`** — replaced `Enum.HasFlag` with a bitwise test. `HasFlag` boxes the receiver and argument on .NET Framework (the JIT only elides it on .NET Core 2.1+). This runs per-packet via the `IsResync` / `IsEndOfStream` / `IsShort` getters.

## Correctness / Reliability

- **`StreamDecoder.DecodeNextPacket`** — `containerOverheadBits` and `bitsRemaining` were assigned for skipped / short / non-audio packets, then unconditionally overwritten with `0` by a trailing reset block before `return null`. Result: those packets reported `0` bits to `_stats.AddPacket`, undercounting `WasteBits` and container overhead. Out-params are now initialized up front and the clobbering block removed.
- **`Extensions.Read`** — the `index >= buffer.Length` guard rejected a valid zero-length read at the buffer end, so `ReadBytes(0)` threw on an empty array. Guard now keys off `count` (`index + count > buffer.Length`).

## Cosmetic

- **`StreamDecoder.SeekTo`** — corrected the copy-pasted `"Could not read pre-roll packet!"` message on the actual seek-packet read path (now `"Could not read seek packet!"`).

## Tests

- New `ExtensionsTests` covering `Read` / `ReadBytes` edge cases (zero-count at buffer end, empty buffer, negative index, count overflow, truncated stream, `ReadBytes(0)`).
- All 163 tests passing (155 prior + 8 new); clean build for `netstandard2.0` and `netstandard2.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)