### PR TITLE
test: unit coverage batch 1 (Floor1, Huffman, Mode, Crc, Utils math)

### DIFF
--- a/NVorbis.Tests/CrcTests.cs
+++ b/NVorbis.Tests/CrcTests.cs
@@ -1,0 +1,81 @@
+using NVorbis.Ogg;
+using Xunit;
+
+namespace NVorbis.Tests
+{
+    public class CrcTests
+    {
+        // Independent bit-by-bit reference for the Ogg CRC (poly 0x04c11db7, MSB-first,
+        // init 0, no input/output reflection, no final xor). Proves the table-driven
+        // Crc class against a simple implementation.
+        private static uint RefCrc(byte[] data)
+        {
+            uint crc = 0;
+            foreach (var b in data)
+            {
+                crc ^= (uint)b << 24;
+                for (int i = 0; i < 8; i++)
+                {
+                    crc = (crc & 0x80000000u) != 0 ? (crc << 1) ^ 0x04c11db7u : crc << 1;
+                }
+            }
+            return crc;
+        }
+
+        [Fact]
+        public void Test_EmptyInput_IsZero()
+        {
+            var crc = new Crc();
+            Assert.True(crc.Test(0u));
+        }
+
+        [Theory]
+        [InlineData(new byte[] { 0x00 })]
+        [InlineData(new byte[] { 0xFF })]
+        [InlineData(new byte[] { 0x4F, 0x67, 0x67, 0x53 })] // "OggS"
+        [InlineData(new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 })]
+        public void Test_MatchesReferenceImplementation(byte[] data)
+        {
+            var crc = new Crc();
+            foreach (var b in data)
+            {
+                crc.Update(b);
+            }
+            Assert.True(crc.Test(RefCrc(data)));
+        }
+
+        [Fact]
+        public void Test_WrongCrc_Fails()
+        {
+            var crc = new Crc();
+            crc.Update(0x42);
+            Assert.False(crc.Test(0u));
+        }
+
+        [Fact]
+        public void Reset_ClearsAccumulator()
+        {
+            var crc = new Crc();
+            crc.Update(0xAB);
+            crc.Update(0xCD);
+            crc.Reset();
+            Assert.True(crc.Test(0u));
+        }
+
+        [Fact]
+        public void Update_IsOrderSensitive()
+        {
+            var a = new Crc();
+            a.Update(0x01);
+            a.Update(0x02);
+
+            var b = new Crc();
+            b.Update(0x02);
+            b.Update(0x01);
+
+            // different byte order must yield a different CRC
+            Assert.False(b.Test(RefCrc(new byte[] { 0x01, 0x02 })));
+            Assert.True(a.Test(RefCrc(new byte[] { 0x01, 0x02 })));
+        }
+    }
+}

--- a/NVorbis.Tests/Floor1Tests.cs
+++ b/NVorbis.Tests/Floor1Tests.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace NVorbis.Tests
+{
+    public class Floor1Tests
+    {
+        static readonly Type _floor1Type = typeof(VorbisReader).Assembly.GetType("NVorbis.Floor1")!;
+        static readonly Type _dataType = _floor1Type.GetNestedType("Data", BindingFlags.NonPublic)!;
+
+        static readonly MethodInfo _renderPoint =
+            _floor1Type.GetMethod("RenderPoint", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        static readonly MethodInfo _unwrapPosts =
+            _floor1Type.GetMethod("UnwrapPosts", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        static void SetField(object target, string name, object value) =>
+            target.GetType().GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(target, value);
+
+        static int RenderPoint(int x0, int y0, int x1, int y1, int x)
+        {
+            var floor = Activator.CreateInstance(_floor1Type, nonPublic: true)!;
+            return (int)_renderPoint.Invoke(floor, new object[] { x0, y0, x1, y1, x })!;
+        }
+
+        // ── RenderPoint: integer line interpolation ──────────────────────────
+
+        [Fact]
+        public void RenderPoint_Midpoint_RisingLine()
+        {
+            Assert.Equal(16, RenderPoint(0, 0, 16, 32, 8));
+        }
+
+        [Fact]
+        public void RenderPoint_QuarterPoint_RisingLine()
+        {
+            Assert.Equal(8, RenderPoint(0, 0, 16, 32, 4));
+        }
+
+        [Fact]
+        public void RenderPoint_FallingLine()
+        {
+            Assert.Equal(16, RenderPoint(0, 32, 16, 0, 8));
+        }
+
+        [Fact]
+        public void RenderPoint_FlatLine_ReturnsConstant()
+        {
+            Assert.Equal(10, RenderPoint(0, 10, 16, 10, 8));
+        }
+
+        [Fact]
+        public void RenderPoint_AtStart_ReturnsY0()
+        {
+            Assert.Equal(5, RenderPoint(0, 5, 16, 100, 0));
+        }
+
+        // ── UnwrapPosts: dequantization of floor posts ───────────────────────
+
+        // build a 3-post floor where post 2 sits at x=8 between posts 0 (x=0) and 1 (x=16)
+        static object MakeFloor(int range)
+        {
+            var floor = Activator.CreateInstance(_floor1Type, nonPublic: true)!;
+            SetField(floor, "_range", range);
+            SetField(floor, "_xList", new[] { 0, 16, 8 });
+            SetField(floor, "_lNeigh", new[] { 0, 0, 0 });
+            SetField(floor, "_hNeigh", new[] { 0, 0, 1 });
+            return floor;
+        }
+
+        static object MakeData(params int[] posts)
+        {
+            var data = Activator.CreateInstance(_dataType, nonPublic: true)!;
+            var arr = (int[])_dataType.GetField("Posts", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(data)!;
+            Array.Copy(posts, arr, posts.Length);
+            _dataType.GetField("PostCount", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(data, posts.Length);
+            return data;
+        }
+
+        static int[] Posts(object data) =>
+            (int[])_dataType.GetField("Posts", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(data)!;
+
+        static bool[] UnwrapPosts(object floor, object data) =>
+            (bool[])_unwrapPosts.Invoke(floor, new object[] { data })!;
+
+        [Fact]
+        public void UnwrapPosts_ZeroPost_KeepsPredictedValue()
+        {
+            // posts 0 and 1 both 100 → predicted at x=8 is 100; a 0 delta leaves it there
+            var floor = MakeFloor(256);
+            var data = MakeData(100, 100, 0);
+            var flags = UnwrapPosts(floor, data);
+
+            Assert.Equal(100, Posts(data)[2]);
+            Assert.False(flags[2]); // no step at a zero post
+        }
+
+        [Fact]
+        public void UnwrapPosts_EvenDelta_AddsHalf()
+        {
+            var floor = MakeFloor(256);
+            var data = MakeData(100, 100, 4); // predicted 100, even delta 4 → +2
+            UnwrapPosts(floor, data);
+            Assert.Equal(102, Posts(data)[2]);
+        }
+
+        [Fact]
+        public void UnwrapPosts_OddDelta_SubtractsHalfRoundedUp()
+        {
+            var floor = MakeFloor(256);
+            var data = MakeData(100, 100, 3); // predicted 100, odd delta 3 → -2
+            UnwrapPosts(floor, data);
+            Assert.Equal(98, Posts(data)[2]);
+        }
+
+        [Fact]
+        public void UnwrapPosts_NonZeroPost_SetsStepFlag()
+        {
+            var floor = MakeFloor(256);
+            var data = MakeData(100, 100, 4);
+            var flags = UnwrapPosts(floor, data);
+            Assert.True(flags[2]);
+        }
+
+        [Fact]
+        public void UnwrapPosts_EndpointsUnchanged()
+        {
+            var floor = MakeFloor(256);
+            var data = MakeData(40, 70, 4);
+            UnwrapPosts(floor, data);
+            Assert.Equal(40, Posts(data)[0]);
+            Assert.Equal(70, Posts(data)[1]);
+        }
+    }
+}

--- a/NVorbis.Tests/HuffmanTests.cs
+++ b/NVorbis.Tests/HuffmanTests.cs
@@ -1,0 +1,87 @@
+using System.Linq;
+using Xunit;
+
+namespace NVorbis.Tests
+{
+    public class HuffmanTests
+    {
+        private static Huffman Generate(int[] lengths, int[] codes, int[] values = null)
+        {
+            var h = new Huffman();
+            h.GenerateTable(values ?? Enumerable.Range(0, lengths.Length).ToArray(), lengths, codes);
+            return h;
+        }
+
+        [Fact]
+        public void TableBits_EqualsMaxLength_WhenUnderCap()
+        {
+            var h = Generate(new[] { 3 }, new[] { 0 });
+            Assert.Equal(3, h.TableBits);
+            Assert.Equal(1 << 3, h.PrefixTree.Count);
+        }
+
+        [Fact]
+        public void PrefixTree_MapsCodesToValues()
+        {
+            // two 1-bit codes: code 0 → value 10, code 1 → value 20
+            var h = Generate(new[] { 1, 1 }, new[] { 0, 1 }, new[] { 10, 20 });
+            Assert.Equal(1, h.TableBits);
+            Assert.Equal(2, h.PrefixTree.Count);
+            Assert.Equal(10, h.PrefixTree[0].Value);
+            Assert.Equal(20, h.PrefixTree[1].Value);
+        }
+
+        [Fact]
+        public void PrefixTree_ShorterCode_FillsMultipleSlots()
+        {
+            // one 1-bit code (bits=0) in a 2-bit table fills both slots whose low bit is 0
+            var h = Generate(new[] { 1, 2 }, new[] { 0, 1 }, new[] { 7, 9 });
+            Assert.Equal(2, h.TableBits);
+            // idx 0b00 and 0b10 → the length-1 entry (value 7)
+            Assert.Equal(7, h.PrefixTree[0].Value);
+            Assert.Equal(7, h.PrefixTree[2].Value);
+            // idx 0b01 → length-2 entry (value 9)
+            Assert.Equal(9, h.PrefixTree[1].Value);
+        }
+
+        [Fact]
+        public void UnusedEntries_AreSkipped()
+        {
+            // length <= 0 marks an unused entry; it must not appear in the prefix tree
+            var h = Generate(new[] { 1, 0 }, new[] { 0, 0 }, new[] { 5, 99 });
+            Assert.DoesNotContain(h.PrefixTree.Where(n => n != null), n => n.Value == 99);
+            Assert.Contains(h.PrefixTree.Where(n => n != null), n => n.Value == 5);
+        }
+
+        [Fact]
+        public void AllUnused_ProducesEmptyTable()
+        {
+            var h = Generate(new[] { 0, 0 }, new[] { 0, 0 });
+            Assert.Equal(0, h.TableBits);
+            Assert.Single(h.PrefixTree); // 1 << 0
+            Assert.Null(h.OverflowList);
+        }
+
+        [Fact]
+        public void LengthOverCap_GoesToOverflowList()
+        {
+            // MAX_TABLE_BITS is 10; an 11-bit code can't fit the prefix table
+            var h = Generate(new[] { 11 }, new[] { 0 }, new[] { 42 });
+            Assert.Equal(10, h.TableBits);
+            Assert.NotNull(h.OverflowList);
+            Assert.Contains(h.OverflowList, n => n.Value == 42);
+        }
+
+        [Fact]
+        public void Sorted_ByLengthThenBits()
+        {
+            // entries provided out of order; prefix fill should still resolve correctly
+            var h = Generate(new[] { 2, 1 }, new[] { 1, 0 }, new[] { 100, 200 });
+            // value 200 has length 1, bits 0 → fills 0b00 and 0b10
+            Assert.Equal(200, h.PrefixTree[0].Value);
+            Assert.Equal(200, h.PrefixTree[2].Value);
+            // value 100 has length 2, bits 1 → 0b01
+            Assert.Equal(100, h.PrefixTree[1].Value);
+        }
+    }
+}

--- a/NVorbis.Tests/ModeTests.cs
+++ b/NVorbis.Tests/ModeTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace NVorbis.Tests
+{
+    public class ModeTests
+    {
+        static readonly Type _modeType = typeof(VorbisReader).Assembly.GetType("NVorbis.Mode")!;
+
+        static readonly MethodInfo _calcWindow =
+            _modeType.GetMethod("CalcWindow", BindingFlags.NonPublic | BindingFlags.Static)!;
+        static readonly MethodInfo _calcOverlap =
+            _modeType.GetMethod("CalcOverlap", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        static float[] CalcWindow(int prev, int block, int next) =>
+            (float[])_calcWindow.Invoke(null, new object[] { prev, block, next })!;
+
+        static (int start, int valid, int total) CalcOverlap(int prev, int block, int next)
+        {
+            var info = _calcOverlap.Invoke(null, new object[] { prev, block, next })!;
+            var t = info.GetType();
+            int F(string n) => (int)t.GetField(n, BindingFlags.Public | BindingFlags.Instance)!.GetValue(info)!;
+            return (F("PacketStartIndex"), F("PacketValidLength"), F("PacketTotalLength"));
+        }
+
+        // ── CalcWindow ───────────────────────────────────────────────────────
+
+        [Fact]
+        public void CalcWindow_LengthEqualsBlockSize()
+        {
+            Assert.Equal(256, CalcWindow(256, 256, 256).Length);
+        }
+
+        [Fact]
+        public void CalcWindow_AllValuesInUnitRange()
+        {
+            foreach (var v in CalcWindow(256, 256, 256))
+            {
+                Assert.InRange(v, 0f, 1f);
+            }
+        }
+
+        [Fact]
+        public void CalcWindow_RisingHalf_IsMonotonic()
+        {
+            var w = CalcWindow(256, 256, 256);
+            for (int i = 1; i < 128; i++)
+            {
+                Assert.True(w[i] >= w[i - 1], $"w[{i}]={w[i]} < w[{i - 1}]={w[i - 1]}");
+            }
+        }
+
+        [Fact]
+        public void CalcWindow_Endpoints_AreNearZeroAndOne()
+        {
+            var w = CalcWindow(256, 256, 256);
+            Assert.True(w[0] < 0.05f, $"start {w[0]}");
+            Assert.True(w[127] > 0.99f, $"peak {w[127]}");
+        }
+
+        [Fact]
+        public void CalcWindow_SatisfiesPrincenBradleyIdentity()
+        {
+            // For the symmetric case, w[i]^2 + w[i+half]^2 == 1 (perfect reconstruction)
+            var w = CalcWindow(256, 256, 256);
+            for (int i = 0; i < 128; i++)
+            {
+                var sum = w[i] * w[i] + w[i + 128] * w[i + 128];
+                Assert.Equal(1f, sum, 4); // 4 decimal places
+            }
+        }
+
+        [Fact]
+        public void CalcWindow_LeadingRegion_IsZeroForLongBlock()
+        {
+            // long block with short neighbors: samples before the ramp are zero
+            var w = CalcWindow(256, 2048, 256);
+            // leftbegin = 2048/4 - (256/2)/2 = 512 - 64 = 448
+            Assert.Equal(0f, w[0]);
+            Assert.Equal(0f, w[447]);
+            Assert.True(w[448] > 0f);
+        }
+
+        // ── CalcOverlap ──────────────────────────────────────────────────────
+
+        [Fact]
+        public void CalcOverlap_Symmetric()
+        {
+            var (start, valid, total) = CalcOverlap(256, 256, 256);
+            Assert.Equal(0, start);
+            Assert.Equal(256, total);
+            Assert.Equal(128, valid);
+        }
+
+        [Fact]
+        public void CalcOverlap_Asymmetric()
+        {
+            var (start, valid, total) = CalcOverlap(128, 256, 512);
+            // leftHalf=32, rightHalf=128; start = 64-32 = 32
+            Assert.Equal(32, start);
+            Assert.Equal(320, total);  // 256/4*3 + 128
+            Assert.Equal(64, valid);   // 320 - 128*2
+        }
+    }
+}

--- a/NVorbis.Tests/UtilsMathTests.cs
+++ b/NVorbis.Tests/UtilsMathTests.cs
@@ -1,0 +1,94 @@
+using Xunit;
+
+namespace NVorbis.Tests
+{
+    public class UtilsMathTests
+    {
+        // ── ilog: number of significant bits ─────────────────────────────────
+
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(1, 1)]
+        [InlineData(2, 2)]
+        [InlineData(3, 2)]
+        [InlineData(7, 3)]
+        [InlineData(8, 4)]
+        [InlineData(255, 8)]
+        [InlineData(256, 9)]
+        public void Ilog_ReturnsBitCount(int value, int expected)
+        {
+            Assert.Equal(expected, Utils.ilog(value));
+        }
+
+        [Fact]
+        public void Ilog_NegativeOrZero_StopsAtZero()
+        {
+            // sign bit set: loop guard is x > 0, so negatives return 0
+            Assert.Equal(0, Utils.ilog(-1));
+        }
+
+        // ── BitReverse ───────────────────────────────────────────────────────
+
+        [Fact]
+        public void BitReverse_Full32_SingleBit()
+        {
+            Assert.Equal(0x80000000u, Utils.BitReverse(1u));
+        }
+
+        [Theory]
+        [InlineData(1u, 1, 1u)]    // 0b1 reversed in 1 bit = 0b1
+        [InlineData(1u, 4, 8u)]    // 0b0001 reversed in 4 bits = 0b1000
+        [InlineData(0b1011u, 4, 0b1101u)]
+        [InlineData(0u, 8, 0u)]
+        public void BitReverse_LimitedBits(uint value, int bits, uint expected)
+        {
+            Assert.Equal(expected, Utils.BitReverse(value, bits));
+        }
+
+        // ── ClipValue ────────────────────────────────────────────────────────
+
+        const float Threshold = 0.99999994f;
+
+        [Fact]
+        public void ClipValue_WithinRange_ReturnsValueUnclipped()
+        {
+            var clipped = false;
+            Assert.Equal(0.5f, Utils.ClipValue(0.5f, ref clipped));
+            Assert.False(clipped);
+        }
+
+        [Fact]
+        public void ClipValue_AboveThreshold_ClampsAndFlags()
+        {
+            var clipped = false;
+            Assert.Equal(Threshold, Utils.ClipValue(1.5f, ref clipped));
+            Assert.True(clipped);
+        }
+
+        [Fact]
+        public void ClipValue_BelowNegativeThreshold_ClampsAndFlags()
+        {
+            var clipped = false;
+            Assert.Equal(-Threshold, Utils.ClipValue(-1.5f, ref clipped));
+            Assert.True(clipped);
+        }
+
+        [Fact]
+        public void ClipValue_ExactlyAtThreshold_DoesNotClip()
+        {
+            // comparison is strictly greater-than, so the threshold itself passes through
+            var clipped = false;
+            Assert.Equal(Threshold, Utils.ClipValue(Threshold, ref clipped));
+            Assert.False(clipped);
+        }
+
+        [Fact]
+        public void ClipValue_DoesNotResetClippedFlag()
+        {
+            // flag is sticky across calls (drives HasClipped)
+            var clipped = true;
+            Utils.ClipValue(0.1f, ref clipped);
+            Assert.True(clipped);
+        }
+    }
+}


### PR DESCRIPTION
Adds direct unit coverage for pure / near-pure units that previously had no dedicated tests, from the coverage-gap analysis.

## New tests

- **Floor1** — `RenderPoint` integer line interpolation (rising/falling/flat/endpoints); `UnwrapPosts` post dequantization (zero delta keeps prediction, even adds half, odd subtracts half-rounded-up, step flags, endpoints unchanged).
- **Huffman** — `GenerateTable`: `TableBits` vs max length, code→value mapping, short-code filling multiple prefix slots, unused-entry (`length <= 0`) skip, all-unused empty table, length-over-`MAX_TABLE_BITS` overflow list, length-then-bits sort order.
- **Mode** — `CalcWindow` length/unit-range/monotonic-rise/endpoints, long-block leading-zero region, and the **Princen-Bradley** perfect-reconstruction identity (`w[i]² + w[i+half]² == 1`); `CalcOverlap` symmetric + asymmetric index math.
- **Crc** — table-driven CRC validated against an independent bit-by-bit reference implementation across several inputs, plus empty/reset/order-sensitivity.
- **Utils** — `ilog`, `BitReverse` (full + limited bits), `ClipValue` threshold boundaries (within range, above/below, exactly at threshold, sticky flag).

## Test plan

- [x] 215 tests passing (163 → 215); no new warnings
- [x] Clean build for `netstandard2.0` and `netstandard2.1`

No production code changed — tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)