### PR TITLE
test: unit coverage batch 3 (GetIsVorbisBugDiff, Floor1.Apply)

### DIFF
--- a/NVorbis.Tests/Floor1Tests.cs
+++ b/NVorbis.Tests/Floor1Tests.cs
@@ -13,6 +13,8 @@ namespace NVorbis.Tests
             _floor1Type.GetMethod("RenderPoint", BindingFlags.NonPublic | BindingFlags.Instance)!;
         static readonly MethodInfo _unwrapPosts =
             _floor1Type.GetMethod("UnwrapPosts", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        static readonly MethodInfo _apply =
+            _floor1Type.GetMethod("Apply", BindingFlags.Public | BindingFlags.Instance)!;
 
         static void SetField(object target, string name, object value) =>
             target.GetType().GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(target, value);
@@ -130,6 +132,71 @@ namespace NVorbis.Tests
             UnwrapPosts(floor, data);
             Assert.Equal(40, Posts(data)[0]);
             Assert.Equal(70, Posts(data)[1]);
+        }
+
+        // ── Apply: render the floor curve into the residue buffer ────────────
+
+        const float DbTable0 = 1.0649863e-07f; // inverse_dB_table[0]
+
+        // 2-post floor spanning [0, n); a single line from post 0 to post 1
+        static object MakeApplyFloor(int n, int multiplier)
+        {
+            var floor = Activator.CreateInstance(_floor1Type, nonPublic: true)!;
+            SetField(floor, "_range", 256);
+            SetField(floor, "_multiplier", multiplier);
+            SetField(floor, "_xList", new[] { 0, n });
+            SetField(floor, "_sortIdx", new[] { 0, 1 });
+            SetField(floor, "_lNeigh", new[] { 0, 0 });
+            SetField(floor, "_hNeigh", new[] { 0, 1 });
+            return floor;
+        }
+
+        static void Apply(object floor, object data, int blockSize, float[] residue) =>
+            _apply.Invoke(floor, new object[] { data, blockSize, residue });
+
+        [Fact]
+        public void Apply_FlatFloorAtZero_MultipliesByTableZero()
+        {
+            const int blockSize = 8; // n = 4
+            var floor = MakeApplyFloor(4, multiplier: 1);
+            var data = MakeData(0, 0); // both posts at y=0 → flat line at dB index 0
+
+            var residue = new[] { 1f, 1f, 1f, 1f, 1f, 1f, 1f, 1f };
+            Apply(floor, data, blockSize, residue);
+
+            // front half scaled by inverse_dB_table[0] (exact: 1f * x == x); back half untouched
+            for (int i = 0; i < 4; i++) Assert.Equal(DbTable0, residue[i]);
+            for (int i = 4; i < 8; i++) Assert.Equal(1f, residue[i]);
+        }
+
+        [Fact]
+        public void Apply_RisingFloor_ProducesMonotonicCurve()
+        {
+            const int blockSize = 8;
+            var floor = MakeApplyFloor(4, multiplier: 1);
+            var data = MakeData(0, 255); // rising from dB index 0 to 255
+
+            var residue = new[] { 1f, 1f, 1f, 1f };
+            Apply(floor, data, blockSize, residue);
+
+            // inverse_dB_table is strictly increasing, so a rising floor yields a rising curve
+            Assert.True(residue[1] > residue[0]);
+            Assert.True(residue[2] > residue[1]);
+            Assert.True(residue[3] > residue[2]);
+        }
+
+        [Fact]
+        public void Apply_NoPosts_ClearsResidue()
+        {
+            const int blockSize = 8;
+            var floor = MakeApplyFloor(4, multiplier: 1);
+            var data = MakeData(); // PostCount == 0
+
+            var residue = new[] { 1f, 1f, 1f, 1f, 1f, 1f, 1f, 1f };
+            Apply(floor, data, blockSize, residue);
+
+            // no energy → front half cleared
+            for (int i = 0; i < 4; i++) Assert.Equal(0f, residue[i]);
         }
     }
 }

--- a/NVorbis.Tests/PacketProviderBugDiffTests.cs
+++ b/NVorbis.Tests/PacketProviderBugDiffTests.cs
@@ -1,0 +1,78 @@
+using NVorbis.Contracts;
+using NVorbis.Contracts.Ogg;
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace NVorbis.Tests
+{
+    // Direct coverage for PacketProvider.GetIsVorbisBugDiff: the bit-math that recognizes
+    // the libvorbis long->short granule miscount. The recognized difference is always
+    // (1<<a) - (1<<b) for a > b, i.e. a single contiguous run of 1 bits; anything with a
+    // gap in the 1 bits is not the bug. (issue #28 exercises this end-to-end; this pins the
+    // function in isolation.)
+    public class PacketProviderBugDiffTests
+    {
+        private class StubStreamPageReader : IStreamPageReader
+        {
+            public IPacketProvider PacketProvider => null;
+            public void AddPage() { }
+            public Memory<byte>[] GetPagePackets(int pageIndex) => null;
+            public int FindPage(long granulePos) => -1;
+            public bool GetPage(int pageIndex, out long granulePos, out bool isResync, out bool isContinuation, out bool isContinued, out int packetCount, out int pageOverhead)
+            {
+                granulePos = 0; isResync = false; isContinuation = false; isContinued = false; packetCount = 0; pageOverhead = 0;
+                return false;
+            }
+            public void SetEndOfStream() { }
+            public int PageCount => 0;
+            public bool HasAllPages => true;
+            public long? MaxGranulePosition => 0;
+            public int FirstDataPageIndex => 0;
+        }
+
+        private static readonly Type _ppType = typeof(VorbisReader).Assembly.GetType("NVorbis.Ogg.PacketProvider")!;
+        private static readonly MethodInfo _bugDiff =
+            _ppType.GetMethod("GetIsVorbisBugDiff", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static bool IsBugDiff(long diff)
+        {
+            var pp = Activator.CreateInstance(
+                _ppType,
+                BindingFlags.NonPublic | BindingFlags.Instance,
+                null,
+                new object[] { new StubStreamPageReader(), 0 },
+                null)!;
+            return (bool)_bugDiff.Invoke(pp, new object[] { diff })!;
+        }
+
+        [Theory]
+        [InlineData(448)]  // 2048/256 → 512-64, 0b111000000
+        [InlineData(192)]  // 1024/256 → 256-64, 0b11000000
+        [InlineData(480)]  // 2048/128 → 512-32, 0b111100000
+        [InlineData(96)]   // 128-32, 0b1100000
+        [InlineData(6)]    // 8-2,  0b110
+        [InlineData(7)]    // 8-1,  0b111
+        public void ContiguousOneRun_IsBugDiff(long diff)
+        {
+            Assert.True(IsBugDiff(diff));
+        }
+
+        [Fact]
+        public void NegativeDiff_UsesAbsoluteValue()
+        {
+            Assert.True(IsBugDiff(-448));
+        }
+
+        [Theory]
+        [InlineData(5)]    // 0b101  — gap
+        [InlineData(10)]   // 0b1010 — gap
+        [InlineData(20)]   // 0b10100 — gap
+        [InlineData(100)]  // 0b1100100 — gap
+        [InlineData(320)]  // 0b101000000 — gap
+        public void GappedBits_AreNotBugDiff(long diff)
+        {
+            Assert.False(IsBugDiff(diff));
+        }
+    }
+}


### PR DESCRIPTION
Third (likely final) coverage batch — pins two remaining pieces of logic in isolation.

## New tests

- **`PacketProvider.GetIsVorbisBugDiff`** — the bit-math that recognizes the libvorbis long→short granule miscount. The recognized difference is always `(1<<a) - (1<<b)` for `a > b` (a single contiguous run of 1 bits); a gap in the 1 bits is not the bug. Theory cases pin contiguous runs as true (including the negative/abs path) and gapped values as false. Previously covered only end-to-end via issue #28.
- **`Floor1.Apply`** — renders the floor curve into the residue buffer: a flat floor at dB index 0 scales every sample by `inverse_dB_table[0]` (exact), a rising floor produces a monotonically increasing curve, and a no-post floor clears the residue. Completes Floor1 (RenderPoint / UnwrapPosts landed in batch 1).

## Test plan

- [x] 254 tests passing (239 → 254)
- [x] Clean build for `netstandard2.0` and `netstandard2.1`

Tests only; no production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)