### PR TITLE
CI/packaging cleanup + 1.0.0-beta.1 version bump

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -1,15 +1,17 @@
 name: .NET Core CI
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
   build:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 10.x
       - name: Build with dotnet
         run: dotnet build --configuration Release
       - name: Test with dotnet

--- a/NVorbis/NVorbis.csproj
+++ b/NVorbis/NVorbis.csproj
@@ -10,7 +10,6 @@
     <FileVersion>1.0.0.1</FileVersion>
     <Authors>Andrew Ward</Authors>
     <Version>1.0.0-alpha.2</Version>
-    <PackageLicenseUrl></PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/NVorbis/NVorbis</PackageProjectUrl>
     <PackageReleaseNotes>
 1.0.0-alpha.2:
@@ -52,7 +51,6 @@ Tests:
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <NeutralLanguage>en</NeutralLanguage>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/NVorbis/NVorbis</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/NVorbis/NVorbis.csproj
+++ b/NVorbis/NVorbis.csproj
@@ -72,7 +72,7 @@ Tests:
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Bcl.Numerics" Version="11.0.0-preview.5.26302.115" />
+    <PackageReference Include="Microsoft.Bcl.Numerics" Version="10.0.9" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>

--- a/NVorbis/NVorbis.csproj
+++ b/NVorbis/NVorbis.csproj
@@ -9,7 +9,7 @@
     <AssemblyVersion>1.0.0.1</AssemblyVersion>
     <FileVersion>1.0.0.1</FileVersion>
     <Authors>Andrew Ward</Authors>
-    <Version>1.0.0-alpha.2</Version>
+    <Version>1.0.0-beta.1</Version>
     <PackageProjectUrl>https://github.com/NVorbis/NVorbis</PackageProjectUrl>
     <PackageReleaseNotes>See https://github.com/NVorbis/NVorbis/releases for full release notes.</PackageReleaseNotes>
     <PackageTags>ogg vorbis xiph audio c# sound .NET</PackageTags>

--- a/NVorbis/NVorbis.csproj
+++ b/NVorbis/NVorbis.csproj
@@ -5,48 +5,13 @@
     <RootNamespace>NVorbis</RootNamespace>
     <Description>A fully managed implementation of a Xiph.org Foundation Ogg Vorbis decoder.</Description>
     <Company>Andrew Ward</Company>
-    <Copyright>Copyright © Andrew Ward 2021</Copyright>
+    <Copyright>Copyright © Andrew Ward $([System.DateTime]::Now.Year)</Copyright>
     <AssemblyVersion>1.0.0.1</AssemblyVersion>
     <FileVersion>1.0.0.1</FileVersion>
     <Authors>Andrew Ward</Authors>
     <Version>1.0.0-alpha.2</Version>
     <PackageProjectUrl>https://github.com/NVorbis/NVorbis</PackageProjectUrl>
-    <PackageReleaseNotes>
-1.0.0-alpha.2:
-- Fix dead loop in StreamDecoder.Read on a near-end re-seek + over-read; re-seek is now correct/idempotent (#40, #74)
-- NuGet publish via GitHub OIDC trusted publishing (#73)
-
-1.0.0-alpha.1:
-
-Reliability and correctness:
-- Fix SeekOrigin.Current seeking backward instead of forward (#46)
-- Fix mux submap bounds check off-by-one (#47)
-- Fix seeking to position 0 when the last header page has granule -1 (#55)
-- Bound NormalizePacketIndex walkback at the first data page (#58)
-- Fix three decode bugs surfaced by new tests: PacketCount, FindPacket EOS clipping, SeekTo(TotalSamples) (#59)
-- Remove dead null check, make Dispose idempotent, fix Codebook idxDiv overflow (#61)
-- MDCT double-precision twiddle factors, Floor0 bark-scale precision, Codebook null safety (#63)
-- Correct VerifyPage bounds and VerifyHeader comparison in PageReaderBase (#64)
-- Fix Enum.HasFlag boxing, stats bit undercount, Extensions.Read zero-length guard, seek error message (#68)
-
-Performance:
-- Eliminate per-packet List&lt;int&gt; allocation (#56)
-- Cache page packets to avoid a double read on seek (#57)
-- Lock-free StreamStats and ArrayPool reuse in Residue0 (#60)
-- Use MathF for float arithmetic in the decode paths (#67)
-
-API:
-- New Read(Span&lt;float&gt;) on IStreamDecoder, VorbisReader.OpenAsync, and threading docs (#62)
-
-Packaging and maintenance:
-- Add netstandard2.1 target (#41)
-- Include README.md in the NuGet package (#43)
-- Typos, named constants, readonly fields, drop net45 target (#65)
-- Remove obsolete backward-compatibility shims (#66)
-
-Tests:
-- Add issue #28 regression fixture and unit-coverage batches 1-3 (#59, #69, #70, #71)
-    </PackageReleaseNotes>
+    <PackageReleaseNotes>See https://github.com/NVorbis/NVorbis/releases for full release notes.</PackageReleaseNotes>
     <PackageTags>ogg vorbis xiph audio c# sound .NET</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <NeutralLanguage>en</NeutralLanguage>
@@ -58,6 +23,8 @@ Tests:
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <ItemGroup>
@@ -69,6 +36,10 @@ Tests:
   <ItemGroup>
     <None Include="..\LICENSE" Pack="true" PackagePath="\"  />
     <None Include="..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
## Summary
- Fix CI SDK version mismatch: `dotnetcore.yml` requested .NET 6.0.x but `NVorbis.Tests` targets net10.0 — it only built because `windows-latest` ships extra preinstalled SDKs. Pin to 10.x (matches `publish-nuget.yml`), bump `actions/checkout`/`actions/setup-dotnet` to v4, add `pull_request` trigger so fork PRs get CI.
- Remove dead csproj tags: empty `PackageLicenseUrl` (superseded by `PackageLicenseFile`), duplicate `GeneratePackageOnBuild` (was set twice, second silently won).
- Pin `Microsoft.Bcl.Numerics` to stable `10.0.9`, off the preview `11.0.0-preview.5` it was shipping to consumers.
- Add SourceLink (`Microsoft.SourceLink.GitHub` + `PublishRepositoryUrl`/`EmbedUntrackedSources`) so the published `.snupkg` symbols actually resolve to source for step-through debugging — verified via `dotnet pack`, nuspec now embeds repo url/branch/commit.
- Auto-compute `Copyright` year instead of a hardcoded stale `2021`.
- Slim `PackageReleaseNotes` to point at GitHub Releases instead of inlining a growing multi-release changelog in the csproj.
- Bump `Version` to `1.0.0-beta.1`.

## Test plan
- [x] `dotnet build --configuration Release` — clean, 0 warnings
- [x] `dotnet test` — 258/258 passing
- [x] `dotnet pack` — verified nuspec contains SourceLink repository metadata (url/branch/commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)