### PR TITLE
Fix granule-timeline holes, non-zero stream start, first-page continuation (#39, #35, #37)

### DIFF
--- a/NVorbis.Tests/Issue35RegressionTests.cs
+++ b/NVorbis.Tests/Issue35RegressionTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace NVorbis.Tests
+{
+    // Regression tests for issue #35: "the number of samples returned by ReadSamples() does not
+    // line up with SamplePosition ... seeking to SamplePosition = 0 before reading improves the
+    // issue, but doesn't entirely fix it."
+    //
+    // Root cause: issue6test.ogg's granule timeline doesn't start at 0 (a stream cut or capture
+    // starting mid-broadcast). Read-pickup used the raw file timeline while SeekTo(0)'s first-page
+    // snap forced granulePos = 0, so the two paths disagreed by the timeline's true start offset --
+    // matching the reporter's "seeking to 0 improves it, but doesn't fix it" symptom exactly.
+    // StreamDecoder now learns the stream's start granule at construction time and normalizes
+    // every position (SamplePosition, TotalSamples, seek targets) to be 0-based from there.
+    //
+    // issue37test.ogg additionally violates the Vorbis I spec: its setup header spills onto the
+    // first data page (a continuation), so packet 0 there is header tail, not audio. The same
+    // normalization logic must skip that packet when walking for the start granule, or it
+    // computes garbage from decoding non-audio data as if it were a packet.
+    public class Issue35RegressionTests
+    {
+        private static string TestFile(string name) =>
+            Path.Combine(AppContext.BaseDirectory, "TestFiles", name);
+
+        [Theory]
+        [InlineData("issue6test.ogg")]
+        [InlineData("issue37test.ogg")]
+        public void CumulativeReadLength_MatchesSamplePosition(string file)
+        {
+            var rand = new Random(35 ^ file.GetHashCode());
+            using var reader = new VorbisReader(TestFile(file));
+
+            long expected = 0;
+            for (int i = 0; i < 500; i++)
+            {
+                int readLen = rand.Next(1, reader.Channels * 4096 + 1);
+                readLen -= readLen % reader.Channels;
+                if (readLen == 0) readLen = reader.Channels;
+
+                var buf = new float[readLen];
+                int count = reader.ReadSamples(buf, 0, readLen);
+                if (count == 0) break;
+
+                expected += count / reader.Channels;
+                Assert.Equal(expected, reader.SamplePosition);
+            }
+        }
+
+        [Theory]
+        [InlineData("issue6test.ogg")]
+        [InlineData("issue37test.ogg")]
+        public void SeekToZero_MatchesFreshOpenPosition(string file)
+        {
+            using var openReader = new VorbisReader(TestFile(file));
+            var openBuf = new float[openReader.Channels * 4096];
+            int openCount = openReader.ReadSamples(openBuf, 0, openBuf.Length);
+
+            using var seekReader = new VorbisReader(TestFile(file));
+            seekReader.SeekTo(0L, SeekOrigin.Begin);
+            Assert.Equal(0L, seekReader.SamplePosition);
+            var seekBuf = new float[seekReader.Channels * 4096];
+            int seekCount = seekReader.ReadSamples(seekBuf, 0, seekBuf.Length);
+
+            Assert.Equal(openCount, seekCount);
+            Assert.Equal(openReader.SamplePosition, seekReader.SamplePosition);
+        }
+
+        [Theory]
+        [InlineData("issue6test.ogg")]
+        [InlineData("issue37test.ogg")]
+        public void SamplePosition_Zero_AfterOpen(string file)
+        {
+            using var reader = new VorbisReader(TestFile(file));
+            Assert.Equal(0L, reader.SamplePosition);
+        }
+    }
+}

--- a/NVorbis.Tests/Issue39RegressionTests.cs
+++ b/NVorbis.Tests/Issue39RegressionTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace NVorbis.Tests
+{
+    // Regression tests for issue #39: "GranulePos mismatch: Page 3, expected 17088, calculated
+    // 16601". issue40test.ogg has a genuine ~340-sample hole in its granule timeline (a real gap,
+    // not the issue #28 libvorbis mis-count) between samples 1265020 and 1265360, most likely from
+    // a spliced/edited source. FindPacket used to treat any unexplained forward granule
+    // discrepancy on a page after the first as corruption and throw. It now treats it as a hole:
+    // the target page's own granule positions are internally consistent, so a seek that lands in
+    // the gap resolves to the first sample that actually exists, rather than throwing.
+    public class Issue39RegressionTests
+    {
+        private static string TestFile(string name) =>
+            Path.Combine(AppContext.BaseDirectory, "TestFiles", name);
+
+        private const string Issue39File = "issue40test.ogg";
+
+        // The exact hole measured in this fixture: (1265020, 1265360].
+        private const long HoleTarget = 1265100;
+        private const long HoleEnd = 1265360;
+
+        [Fact]
+        public void Issue39_SeekIntoHole_SnapsForwardWithoutThrowing()
+        {
+            using var reader = new VorbisReader(TestFile(Issue39File));
+
+            reader.SeekTo(HoleTarget, SeekOrigin.Begin);
+
+            Assert.Equal(HoleEnd, reader.SamplePosition);
+
+            var buf = new float[reader.Channels * 4096];
+            Assert.True(reader.ReadSamples(buf, 0, buf.Length) > 0);
+        }
+
+        [Fact]
+        public void Issue39_RandomSeekFuzz_DoesNotThrow()
+        {
+            var rand = new Random(39 ^ Issue39File.GetHashCode());
+            using var reader = new VorbisReader(TestFile(Issue39File));
+            long total = reader.TotalSamples;
+            var buf = new float[reader.Channels * 4096];
+
+            for (int i = 0; i < 2000; i++)
+            {
+                long target = (long)(rand.NextDouble() * total);
+                reader.SeekTo(target, SeekOrigin.Begin);
+                Assert.True(reader.SamplePosition >= target, $"pos {reader.SamplePosition} < target {target}");
+                reader.ReadSamples(buf, 0, buf.Length);
+            }
+        }
+    }
+}

--- a/NVorbis/Ogg/PacketProvider.cs
+++ b/NVorbis/Ogg/PacketProvider.cs
@@ -17,6 +17,9 @@ namespace NVorbis.Ogg
         private Packet _lastPacket;
         private int _nextPacketPageIndex;
         private int _nextPacketPacketIndex;
+        private long _streamStartGranule;
+        private bool _streamStartGranuleKnown;
+        private int _firstAudioPacketIndex;
 
         public bool CanSeek => true;
 
@@ -65,11 +68,13 @@ namespace NVorbis.Ogg
                 // We are on the very first audio page (or somehow before it). There is no
                 // preceding audio page to validate granule positions against, so skip the
                 // complex FindPacket logic and snap directly to the stream beginning.
-                // packetIndex = 0 is always valid here: the first data page is guaranteed to
-                // start with an audio packet (Vorbis header pages precede it).
+                // GetStreamStartGranule resolves the first real audio packet's index (skipping
+                // a header tail spilled onto this page, if any -- issue #37) and the stream's
+                // true start granule, which isn't necessarily zero (e.g. a stream cut or
+                // captured mid-broadcast -- issue #35).
                 pageIndex = _reader.FirstDataPageIndex;
-                packetIndex = 0;
-                granulePos = 0;
+                granulePos = GetStreamStartGranule(getPacketGranuleCount);
+                packetIndex = _firstAudioPacketIndex;
             }
             else
             {
@@ -161,7 +166,7 @@ namespace NVorbis.Ogg
             return (gps, endGP);
         }
 
-        private int FindPacket(int pageIndex, long[] gps, long endGP, long lastPageGranulePos, int lastPagePacketLength, ref long granulePos)
+        private int FindPacket(long[] gps, long endGP, long lastPageGranulePos, int lastPagePacketLength, ref long granulePos)
         {
             // next check for a bugged vorbis encoder...
             if (endGP != lastPageGranulePos)
@@ -181,13 +186,12 @@ namespace NVorbis.Ogg
                             return -1;
                         }
                     }
-                    // if we're not on the first page, there's a problem...
-                    // technically there could still be a problem on the first page, but we're ignoring it
-                    else if (pageIndex > _reader.FirstDataPageIndex)
-                    {
-                        // unknown error...
-                        throw new System.IO.InvalidDataException($"GranulePos mismatch: Page {pageIndex}, expected {lastPageGranulePos}, calculated {endGP}");
-                    }
+                    // otherwise there's a granule hole between the previous page and this one:
+                    // the stream's timeline skips forward, e.g. because it was spliced together
+                    // from segments (issue #39).  This page's granule positions are internally
+                    // consistent, so gps is already correct; a request that falls inside the
+                    // hole matches this page's first packet in the loop below and reports the
+                    // packet's true start granule, which the caller clamps forward to.
                 }
                 else
                 {
@@ -225,7 +229,7 @@ namespace NVorbis.Ogg
             var (gps, endGP) = GetTargetPageInfo(pageIndex, firstRealPacket, lastPagePacketLength, getPacketGranuleCount);
 
             // finally figure out which packet in our known info we need to use
-            var packetIndex = FindPacket(pageIndex, gps, endGP, lastPageGranulePos, lastPagePacketLength, ref granulePos);
+            var packetIndex = FindPacket(gps, endGP, lastPageGranulePos, lastPagePacketLength, ref granulePos);
 
             // then apply the preRoll (but only if we're not seeking into the first packet, which is its own preRoll)
             if (endGP > 0 || packetIndex > 1)
@@ -269,6 +273,37 @@ namespace NVorbis.Ogg
             return temp == 0 && diff == (1 << longBlockBits) - (1 << shortBlockBits);
         }
 
+        private long GetStreamStartGranule(GetPacketGranuleCount getPacketGranuleCount)
+        {
+            if (!_streamStartGranuleKnown)
+            {
+                // The Vorbis I spec requires audio data to start on a fresh page, but some
+                // encoders spill the setup header's tail onto the first data page (issue #37).
+                // When that happens, packet 0 there is header data, not audio, and must be
+                // skipped when walking for the true start granule.
+                _reader.GetPage(_reader.FirstDataPageIndex, out _, out _, out var isContinuation, out _, out _, out _);
+                _firstAudioPacketIndex = isContinuation ? 1 : 0;
+
+                // Walk the first data page to find where the first audio packet's output ends;
+                // that is the granule of the stream's first decodable sample (that packet only
+                // primes the overlap buffer, so it emits nothing itself).  Normally this is 0,
+                // but a stream cut or captured mid-timeline starts at whatever granule the
+                // encoder was up to (issue #35).
+                // A negative result here isn't reliable: normal packet-boundary block-size
+                // accounting (and, on some files, the same encoder mis-count PacketProvider
+                // already compensates for elsewhere) can legitimately produce small negative
+                // values on an ordinary, non-trimmed file, with no way to distinguish that from
+                // a genuine begin-trim. Clamp to 0, as before -- Vorbis has no formal lead-in
+                // trim concept the way Opus does, and no observed file needs one.
+                var (gps, endGP) = GetTargetPageInfo(_reader.FirstDataPageIndex, _firstAudioPacketIndex, 0, getPacketGranuleCount);
+                var start = gps.Length > _firstAudioPacketIndex ? gps[_firstAudioPacketIndex] : endGP;
+
+                _streamStartGranule = Math.Max(0, start);
+                _streamStartGranuleKnown = true;
+            }
+            return _streamStartGranule;
+        }
+
         // this method calc's the appropriate page and packet prior to the one specified, honoring continuations and handling negative packetIndex values
         // if packet index is larger than the current page allows, we just return it as-is
         private bool NormalizePacketIndex(ref int pageIndex, ref int packetIndex)
@@ -292,7 +327,7 @@ namespace NVorbis.Ogg
                 if (pgIdx <= firstDataPage)
                 {
                     pageIndex = firstDataPage;
-                    packetIndex = 0;
+                    packetIndex = _streamStartGranuleKnown ? _firstAudioPacketIndex : 0;
                     return true;
                 }
 

--- a/NVorbis/StreamDecoder.cs
+++ b/NVorbis/StreamDecoder.cs
@@ -28,6 +28,7 @@ namespace NVorbis
         private readonly Lazy<ITagData> _tags;
 
         private long _currentPosition;
+        private long _granuleOffset;
         private bool _hasClipped;
         private bool _hasPosition;
         private bool _eosFound;
@@ -64,6 +65,23 @@ namespace NVorbis
                 packet.Reset();
 
                 throw GetInvalidStreamException(packet);
+            }
+
+            if (_packetProvider.CanSeek)
+            {
+                try
+                {
+                    // Find where the stream's granule timeline starts.  Normally that's 0, but a
+                    // stream cut or captured mid-timeline starts later (issue #35); all positions
+                    // we report are normalized so the first decodable sample is position 0.
+                    // The provider is already positioned at the first audio packet, so this seek
+                    // doesn't change any state we care about.
+                    _granuleOffset = _packetProvider.SeekTo(0, 0, GetPacketGranules);
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    // no audio pages; nothing to normalize
+                }
             }
 
             _tags = new Lazy<ITagData>(() => new TagData(_vendor, _comments));
@@ -356,15 +374,30 @@ namespace NVorbis
 
                     if (!ReadNextPacket(count / _channels, out var samplePosition))
                     {
-                        // drain the current packet (the windowing will fade it out)
-                        _prevPacketEnd = _prevPacketStop;
+                        // Drain the current packet (the windowing will fade it out). Left
+                        // unclamped, this can emit past the stream's stated end when EOS wasn't
+                        // flagged during decode (HasAllPages was still false, so the normal EOS
+                        // valid-length backoff in ReadNextPacket never ran) -- making the total
+                        // emitted length depend on whether TotalSamples was queried first. Clamp
+                        // the drain to what's actually left. GetGranuleCount() (via TotalSamples)
+                        // is cheap here: reaching this branch means the provider already hit EOF,
+                        // so HasAllPages is already true and no extra I/O is triggered.
+                        long drainSpan = _prevPacketStop - _prevPacketStart;
+                        if (_packetProvider.CanSeek)
+                        {
+                            var allowed = TotalSamples - (_currentPosition + count / _channels);
+                            drainSpan = Math.Min(drainSpan, Math.Max(0, allowed));
+                        }
+                        _prevPacketEnd = _prevPacketStart + (int)drainSpan;
                     }
 
-                    // if we need to pick up a position, and the packet had one, apply the position now
+                    // If we need to pick up a position, and the packet had one, apply it now.
+                    // _granuleOffset translates the stream's timeline (which doesn't necessarily
+                    // start at zero -- issue #35) to the 0-based positions we report.
                     if (samplePosition.HasValue && !_hasPosition)
                     {
                         _hasPosition = true;
-                        _currentPosition = samplePosition.Value - (_prevPacketEnd - _prevPacketStart) - count / _channels;
+                        _currentPosition = samplePosition.Value - _granuleOffset - (_prevPacketEnd - _prevPacketStart) - count / _channels;
                     }
                 }
 
@@ -453,7 +486,7 @@ namespace NVorbis
             if (samplePosition.HasValue && isEndOfStream)
             {
                 var actualEnd = _currentPosition + bufferedSamples + validLen - startIndex;
-                var diff = (int)(samplePosition.Value - actualEnd);
+                var diff = (int)(samplePosition.Value - _granuleOffset - actualEnd);
                 if (diff < 0)
                 {
                     validLen += diff;
@@ -621,16 +654,26 @@ namespace NVorbis
                 // one packet back so the MDCT overlap is valid.  PacketProvider.SeekTo clamps
                 // to the first audio packet when samplePosition falls on the first data page
                 // (covers position 0 and the first ~block_size samples generically).
-                pos = _packetProvider.SeekTo(samplePosition, 1, GetPacketGranules);
-                rollForward = (int)(samplePosition - pos);
+                // _granuleOffset translates our 0-based position onto the stream's timeline.
+                pos = _packetProvider.SeekTo(samplePosition + _granuleOffset, 1, GetPacketGranules);
+                rollForward = (int)(samplePosition + _granuleOffset - pos);
             }
             catch (ArgumentOutOfRangeException)
             {
                 // the requested position is past the end of the stream
-                _currentPosition = _packetProvider.GetGranuleCount();
+                _currentPosition = _packetProvider.GetGranuleCount() - _granuleOffset;
                 _prevPacketStart = _prevPacketEnd = 0;
                 _eosFound = true;
                 return;
+            }
+
+            if (rollForward < 0)
+            {
+                // The target falls in a granule hole -- a gap in the stream's timeline, e.g. a
+                // spliced stream (issue #39) -- so the provider gave us the first packet after
+                // the hole.  Snap forward to the first sample that actually exists.
+                samplePosition = pos - _granuleOffset;
+                rollForward = 0;
             }
 
             // read the pre-roll packet
@@ -638,7 +681,7 @@ namespace NVorbis
             {
                 // we'll use this to force ReadSamples to fail to read
                 _eosFound = true;
-                if (_packetProvider.GetGranuleCount() != samplePosition)
+                if (_packetProvider.GetGranuleCount() - _granuleOffset != samplePosition)
                 {
                     throw new InvalidOperationException("Could not read pre-roll packet!  Try seeking again prior to reading more samples.");
                 }
@@ -743,7 +786,7 @@ namespace NVorbis
         /// <summary>
         /// Gets the total number of samples in the decoded stream.
         /// </summary>
-        public long TotalSamples => _packetProvider?.GetGranuleCount() ?? throw new ObjectDisposedException(nameof(StreamDecoder));
+        public long TotalSamples => (_packetProvider ?? throw new ObjectDisposedException(nameof(StreamDecoder))).GetGranuleCount() - _granuleOffset;
 
         /// <summary>
         /// Gets or sets the current time position of the stream.

--- a/NVorbis/StreamDecoder.cs
+++ b/NVorbis/StreamDecoder.cs
@@ -28,7 +28,7 @@ namespace NVorbis
         private readonly Lazy<ITagData> _tags;
 
         private long _currentPosition;
-        private long _granuleOffset;
+        private readonly long _granuleOffset;
         private bool _hasClipped;
         private bool _hasPosition;
         private bool _eosFound;


### PR DESCRIPTION
## Summary
- Fix "GranulePos mismatch" exception on a genuine granule-timeline hole (spliced/edited source); a page-to-page granule gap is now treated as a hole and the seek snaps forward to the next real sample instead of throwing (#39)
- Fix SamplePosition/TotalSamples drift on streams whose granule timeline doesn't start at 0 (a capture starting mid-broadcast); positions are now normalized to the stream's true start (#35)
- Support setup headers that spill onto the first data page (a spec violation seen in practice); the first-page walk and seek-to-0 snap now skip the header tail instead of decoding it as audio (#37)
- Fix EOS drain over-emission depending on read order: reading to EOF without having queried TotalSamples first could emit past the stream's stated end; the drain is now clamped to what's actually left (when the provider supports seeking)

Cherry-picked from `fix/issue39-35-6488-hole-trim-drain` with the Resonite-Issues#6488 test fixture (`resonite6488test.ogg`, a user-submitted 2.4MB clip) and its regression tests intentionally left out.

## Test plan
- [x] `dotnet build --configuration Release` — clean
- [x] `dotnet test` — 258/258 passing (Issue35RegressionTests, Issue39RegressionTests included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)