### PR TITLE
ci: collect code coverage and publish report

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -14,5 +14,21 @@ jobs:
           dotnet-version: 10.x
       - name: Build with dotnet
         run: dotnet build --configuration Release
-      - name: Test with dotnet
-        run: dotnet test
+      - name: Test with coverage
+        run: dotnet test --configuration Release --no-build --collect:"XPlat Code Coverage" --results-directory ./coverage
+      - name: Generate coverage report
+        if: always()
+        run: |
+          dotnet tool install --global dotnet-reportgenerator-globaltool --version 5.5.10
+          reportgenerator "-reports:./coverage/**/coverage.cobertura.xml" "-targetdir:./coverage/report" "-reporttypes:Html;TextSummary;MarkdownSummaryGithub"
+      - name: Write coverage to job summary
+        if: always()
+        shell: bash
+        run: cat ./coverage/report/SummaryGithub.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: ./coverage/report
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@
 
 # Local coverage runs
 coverage.cobertura.xml
+coverage/
 coveragereport/
+*.coverage
 
 # User-specific files
 *.suo

--- a/NVorbis.Tests/NVorbis.Tests.csproj
+++ b/NVorbis.Tests/NVorbis.Tests.csproj
@@ -13,6 +13,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## What

Wires up reproducible code coverage in CI. No coverage tooling was committed before — the `coverage.cobertura.xml` / `coveragereport/` files that showed up locally were ad-hoc output, not reproducible and not part of CI.

## Changes

- **`NVorbis.Tests.csproj`** — add `coverlet.collector` so `dotnet test --collect:"XPlat Code Coverage"` produces a cobertura report deterministically (instead of relying on whatever's cached on the dev machine).
- **`.github/workflows/dotnetcore.yml`** — the CI job now:
  - runs tests with coverage collection,
  - renders the result with ReportGenerator,
  - writes a coverage summary to the GitHub **job summary**,
  - uploads the full HTML report as a **`coverage-report` artifact**.
  - All report steps run under `if: always()` so coverage still publishes when a test fails.
- **`.gitignore`** — ignore `coverage/` and `*.coverage`.

## Why self-contained

No external service or secret required — coverage is visible in the job summary and downloadable as an artifact on every push/PR. (Codecov badge/PR-comments can be layered on later if wanted; it just needs the repo enabled on codecov.io + a `CODECOV_TOKEN` secret.)

## Verification

Ran the exact CI sequence locally (build Release → `--no-build` test → collect → ReportGenerator):

- 380 tests pass
- **94% line coverage, 87% branch coverage**
- cobertura + HTML report generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)