### PR TITLE
build: adopt Nerdbank.GitVersioning for automated versioning

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history so Nerdbank.GitVersioning can compute the version
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history so Nerdbank.GitVersioning can compute the version
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
@@ -27,6 +29,8 @@ jobs:
     environment: nuget-publish
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history so Nerdbank.GitVersioning can compute the version
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:

--- a/NVorbis/NVorbis.csproj
+++ b/NVorbis/NVorbis.csproj
@@ -6,10 +6,8 @@
     <Description>A fully managed implementation of a Xiph.org Foundation Ogg Vorbis decoder.</Description>
     <Company>Andrew Ward</Company>
     <Copyright>Copyright © Andrew Ward $([System.DateTime]::Now.Year)</Copyright>
-    <AssemblyVersion>1.0.0.1</AssemblyVersion>
-    <FileVersion>1.0.0.1</FileVersion>
     <Authors>Andrew Ward</Authors>
-    <Version>1.0.0-beta.1</Version>
+    <!-- Version, AssemblyVersion, and FileVersion are supplied by Nerdbank.GitVersioning (version.json). -->
     <PackageProjectUrl>https://github.com/NVorbis/NVorbis</PackageProjectUrl>
     <PackageReleaseNotes>See https://github.com/NVorbis/NVorbis/releases for full release notes.</PackageReleaseNotes>
     <PackageTags>ogg vorbis xiph audio c# sound .NET</PackageTags>
@@ -41,6 +39,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.10.91" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/version.json
+++ b/version.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "1.0.0-rc.{height}",
+  "assemblyVersion": {
+    "precision": "minor"
+  },
+  "nuGetPackageVersion": {
+    "semVer": 2
+  },
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$",
+    "^refs/heads/release/.*$",
+    "^refs/tags/v\\d+\\.\\d+"
+  ]
+}


### PR DESCRIPTION
## What

Replaces the hand-maintained version numbers in `NVorbis.csproj` with [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning) (NBGV) driven by a `version.json`. The package version now advances automatically with git height; `AssemblyVersion` stays pinned for binding-redirect stability.

## Changes

- **`version.json`** (new, repo root): `"version": "1.0.0-rc.{height}"` → NuGetPackageVersion advances by git height (`1.0.0-rc.1`, `rc.2`, …). `assemblyVersion.precision: "minor"` pins **AssemblyVersion = 1.0.0.0** across all prereleases. `publicReleaseRefSpec` covers `master`, `release/*`, and `vX.Y` tags.
- **`NVorbis.csproj`**: removed `<Version>` / `<AssemblyVersion>` / `<FileVersion>`; added `Nerdbank.GitVersioning` PackageReference (`PrivateAssets=All`).
- **CI (`dotnetcore.yml`, `publish-nuget.yml`)**: `fetch-depth: 0` on all checkout steps so NBGV has full history to compute height.

## Notes / rationale

- **Why NBGV over MinVer:** MinVer makes AssemblyVersion track the package version, undoing the intentional freeze. NBGV's `assemblyVersion.precision` keeps AssemblyVersion pinned declaratively while the NuGet version keeps moving.
- **rc, not beta:** `1.0.0-beta.1` is already published on nuget.org. A `beta.{height}` scheme would recompute `beta.1` and `dotnet nuget push --skip-duplicate` would silently skip every build. Starting the `rc` series sidesteps the collision (first automated publish = `1.0.0-rc.1`).
- **Release-tag publish:** `publish-nuget.yml` triggers on `release: published`, where the checkout ref is the tag (not `master`). The `^refs/tags/v\d+\.\d+` entry in `publicReleaseRefSpec` makes NBGV treat that build as a public release, so the pushed package gets a clean version with no `-gCOMMIT` suffix.
- AssemblyVersion changes `1.0.0.1` → `1.0.0.0` (precision `minor`). Acceptable during prerelease — no stable consumers pinned to `.1`.

## Release flow after this merges

1. Merge work to `master`.
2. `nbgv get-version` → shows e.g. `1.0.0-rc.3`.
3. Create a GitHub Release with tag `v1.0.0-rc.3` targeting master.
4. `publish-nuget.yml` packs (NBGV stamps the version) and pushes to nuget.org.

## Verification

- `nbgv get-version` on branch → `NuGetPackageVersion: 1.0.0-rc.1`, `AssemblyVersion: 1.0.0.0`
- `dotnet pack` produces `NVorbis.1.0.0-rc.1.*.nupkg`
- Build succeeds; full test suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)